### PR TITLE
회원가입 리팩토링

### DIFF
--- a/src/main/java/com/cvsgo/service/UserService.java
+++ b/src/main/java/com/cvsgo/service/UserService.java
@@ -47,7 +47,7 @@ public class UserService {
     public SignUpResponseDto signUp(SignUpRequestDto request) {
         List<Tag> tags = tagRepository.findAllById(request.getTagIds());
         try {
-            User user = userRepository.saveAndFlush(request.toEntity(passwordEncoder, tags));
+            User user = userRepository.save(request.toEntity(passwordEncoder, tags));
             return SignUpResponseDto.from(user);
         } catch (DataIntegrityViolationException e) {
             entityManager.clear();

--- a/src/main/java/com/cvsgo/service/UserService.java
+++ b/src/main/java/com/cvsgo/service/UserService.java
@@ -7,6 +7,8 @@ import com.cvsgo.entity.User;
 import com.cvsgo.repository.TagRepository;
 import com.cvsgo.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import com.cvsgo.exception.user.DuplicateEmailException;
+import com.cvsgo.exception.user.DuplicateNicknameException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -35,8 +37,8 @@ public class UserService {
      *
      * @param request 등록할 사용자의 정보
      * @return 등록된 사용자 정보
-     * @throws com.cvsgo.exception.user.DuplicateEmailException 이메일이 중복된 경우
-     * @throws com.cvsgo.exception.user.DuplicateNicknameException 닉네임이 중복된 경우
+     * @throws DuplicateEmailException 이메일이 중복된 경우
+     * @throws DuplicateNicknameException 닉네임이 중복된 경우
      */
     @Transactional
     public SignUpResponseDto signUp(SignUpRequestDto request) {

--- a/src/main/java/com/cvsgo/service/UserService.java
+++ b/src/main/java/com/cvsgo/service/UserService.java
@@ -71,7 +71,7 @@ public class UserService {
      * @return 해당 이메일로 등록된 사용자 존재 여부
      */
     @Transactional(readOnly = true)
-    public Boolean isDuplicatedEmail(String email) {
+    public boolean isDuplicatedEmail(String email) {
         return userRepository.findByUserId(email).isPresent();
     }
 
@@ -82,7 +82,7 @@ public class UserService {
      * @return 해당 닉네임을 가진 사용자 존재 여부
      */
     @Transactional(readOnly = true)
-    public Boolean isDuplicatedNickname(String nickname) {
+    public boolean isDuplicatedNickname(String nickname) {
         return userRepository.findByNickname(nickname).isPresent();
     }
 }

--- a/src/main/java/com/cvsgo/service/UserService.java
+++ b/src/main/java/com/cvsgo/service/UserService.java
@@ -6,6 +6,8 @@ import com.cvsgo.entity.Tag;
 import com.cvsgo.entity.User;
 import com.cvsgo.repository.TagRepository;
 import com.cvsgo.repository.UserRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import lombok.RequiredArgsConstructor;
 import com.cvsgo.exception.user.DuplicateEmailException;
 import com.cvsgo.exception.user.DuplicateNicknameException;
@@ -13,7 +15,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
@@ -32,6 +33,8 @@ public class UserService {
 
     private final PasswordEncoder passwordEncoder;
 
+    private final EntityManager entityManager;
+
     /**
      * 사용자를 등록한다.
      *
@@ -47,6 +50,7 @@ public class UserService {
             User user = userRepository.saveAndFlush(request.toEntity(passwordEncoder, tags));
             return SignUpResponseDto.from(user);
         } catch (DataIntegrityViolationException e) {
+            entityManager.clear();
             if (isDuplicatedEmail(request.getEmail())) {
                 log.info("중복된 이메일: '{}'", request.getEmail());
                 throw DUPLICATE_EMAIL;
@@ -66,7 +70,7 @@ public class UserService {
      * @param email 이메일
      * @return 해당 이메일로 등록된 사용자 존재 여부
      */
-    @Transactional(readOnly = true, propagation = Propagation.REQUIRES_NEW)
+    @Transactional(readOnly = true)
     public Boolean isDuplicatedEmail(String email) {
         return userRepository.findByUserId(email).isPresent();
     }
@@ -77,7 +81,7 @@ public class UserService {
      * @param nickname 닉네임
      * @return 해당 닉네임을 가진 사용자 존재 여부
      */
-    @Transactional(readOnly = true, propagation = Propagation.REQUIRES_NEW)
+    @Transactional(readOnly = true)
     public Boolean isDuplicatedNickname(String nickname) {
         return userRepository.findByNickname(nickname).isPresent();
     }

--- a/src/main/java/com/cvsgo/service/UserService.java
+++ b/src/main/java/com/cvsgo/service/UserService.java
@@ -37,7 +37,7 @@ public class UserService {
      *
      * @param request 등록할 사용자의 정보
      * @return 등록된 사용자 정보
-     * @throws DuplicateEmailException 이메일이 중복된 경우
+     * @throws DuplicateEmailException    이메일이 중복된 경우
      * @throws DuplicateNicknameException 닉네임이 중복된 경우
      */
     @Transactional
@@ -62,6 +62,7 @@ public class UserService {
 
     /**
      * 이메일 중복 체크를 한다.
+     *
      * @param email 이메일
      * @return 해당 이메일로 등록된 사용자 존재 여부
      */
@@ -72,6 +73,7 @@ public class UserService {
 
     /**
      * 닉네임 중복 체크를 한다.
+     *
      * @param nickname 닉네임
      * @return 해당 닉네임을 가진 사용자 존재 여부
      */


### PR DESCRIPTION
### 🎯 Issue
- #36 

### 🔑 Key Changes
- 동시에 같은 이메일/닉네임으로 회원가입시 정상적인 에러 메시지를 응답하지 못 할 수도 있던 부분을, DB의 UNIQUE 제약조건 위반시 발생하는 DataIntegrityViolation을 catch 하여 정상적인 에러메시지를 응답할 수 있도록 수정했습니다.
- UNIQUE 제약조건 위반시 어떤 항목이 중복되었는지 확인하기 위해 rollback된 이후 영속성 컨텍스트를 clear하도록 수정했습니다.
- Google code style에 맞게 기존 코드를 포맷팅했습니다.

