### PR TITLE
특정 상품의 리뷰 목록 조회 기능 추가

### DIFF
--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -108,9 +108,9 @@ create table review (
                         created_at datetime,
                         modified_at datetime,
                         content TEXT not null,
-                        rating integer,
-                        product_id bigint,
-                        user_id bigint,
+                        rating integer not null,
+                        product_id bigint not null,
+                        user_id bigint not null,
                         like_count bigint default 0 not null,
                         primary key (id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/src/docs/asciidoc/api-doc.adoc
+++ b/src/docs/asciidoc/api-doc.adoc
@@ -238,3 +238,21 @@ include::{snippets}/review-controller-test/respond_200_when_success_to_read_revi
 include::{snippets}/review-controller-test/respond_200_when_success_to_read_reviews/response-fields.adoc[]
 ==== Sample Response
 include::{snippets}/review-controller-test/respond_200_when_success_to_read_reviews/http-response.adoc[]
+
+=== 4-4. 특정 상품의 리뷰 목록 조회
+==== Request Fields
+include::{snippets}/review-controller-test/respond_200_when_success_to_read_product_reviews/request-fields.adoc[]
+==== 정렬 기준 항목
+|===
+| sortBy 값 | 정렬 기준 | 비고
+
+| LATEST | 최신순  | 정렬 기준 미지정시 기본값
+| LIKE | 좋아요순 |
+| RATING | 별점순 |
+|===
+==== Sample Request
+include::{snippets}/review-controller-test/respond_200_when_success_to_read_product_reviews/http-request.adoc[]
+==== Response Fields
+include::{snippets}/review-controller-test/respond_200_when_success_to_read_product_reviews/response-fields.adoc[]
+==== Sample Response
+include::{snippets}/review-controller-test/respond_200_when_success_to_read_product_reviews/http-response.adoc[]

--- a/src/main/java/com/cvsgo/controller/ReviewController.java
+++ b/src/main/java/com/cvsgo/controller/ReviewController.java
@@ -55,7 +55,7 @@ public class ReviewController {
         @PathVariable Long productId, @ModelAttribute ReadReviewRequestDto request,
         Pageable pageable) {
         return SuccessResponse.from(
-            reviewService.getProductReviewList(user, productId, request, pageable));
+            reviewService.readProductReviewList(user, productId, request, pageable));
     }
 
     @PutMapping("/reviews/{reviewId}")

--- a/src/main/java/com/cvsgo/controller/ReviewController.java
+++ b/src/main/java/com/cvsgo/controller/ReviewController.java
@@ -15,6 +15,7 @@ import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -50,7 +51,7 @@ public class ReviewController {
     }
 
     @GetMapping("/products/{productId}/reviews")
-    public SuccessResponse<List<ReadReviewResponseDto>> readReviews(@LoginUser User user,
+    public SuccessResponse<Page<ReadReviewResponseDto>> readReviews(@LoginUser User user,
         @PathVariable Long productId, @ModelAttribute ReadReviewRequestDto request,
         Pageable pageable) {
         return SuccessResponse.from(

--- a/src/main/java/com/cvsgo/controller/ReviewController.java
+++ b/src/main/java/com/cvsgo/controller/ReviewController.java
@@ -50,7 +50,7 @@ public class ReviewController {
     }
 
     @GetMapping("/products/{productId}/reviews")
-    public SuccessResponse<List<ReadReviewResponseDto>> searchReviews(@LoginUser User user,
+    public SuccessResponse<List<ReadReviewResponseDto>> readReviews(@LoginUser User user,
         @PathVariable Long productId, @ModelAttribute ReadReviewRequestDto request,
         Pageable pageable) {
         return SuccessResponse.from(

--- a/src/main/java/com/cvsgo/controller/ReviewController.java
+++ b/src/main/java/com/cvsgo/controller/ReviewController.java
@@ -3,6 +3,8 @@ package com.cvsgo.controller;
 import com.cvsgo.argumentresolver.LoginUser;
 import com.cvsgo.dto.SuccessResponse;
 import com.cvsgo.dto.review.CreateReviewRequestDto;
+import com.cvsgo.dto.review.ReadReviewRequestDto;
+import com.cvsgo.dto.review.ReadReviewResponseDto;
 import com.cvsgo.dto.review.SearchReviewRequestDto;
 import com.cvsgo.dto.review.SearchReviewResponseDto;
 import com.cvsgo.dto.review.UpdateReviewRequestDto;
@@ -45,6 +47,14 @@ public class ReviewController {
     public SuccessResponse<List<SearchReviewResponseDto>> searchReviews(@LoginUser User user,
         @ModelAttribute SearchReviewRequestDto request, Pageable pageable) {
         return SuccessResponse.from(reviewService.getReviewList(user, request, pageable));
+    }
+
+    @GetMapping("/products/{productId}/reviews")
+    public SuccessResponse<List<ReadReviewResponseDto>> searchReviews(@LoginUser User user,
+        @PathVariable Long productId, @ModelAttribute ReadReviewRequestDto request,
+        Pageable pageable) {
+        return SuccessResponse.from(
+            reviewService.getProductReviewList(user, productId, request, pageable));
     }
 
     @PutMapping("/reviews/{reviewId}")

--- a/src/main/java/com/cvsgo/dto/review/ReadReviewQueryDto.java
+++ b/src/main/java/com/cvsgo/dto/review/ReadReviewQueryDto.java
@@ -4,6 +4,7 @@ import com.cvsgo.entity.Review;
 import com.cvsgo.entity.User;
 import com.cvsgo.entity.UserFollow;
 import com.querydsl.core.annotations.QueryProjection;
+import java.time.LocalDateTime;
 import lombok.Getter;
 
 @Getter
@@ -25,6 +26,8 @@ public class ReadReviewQueryDto {
 
     private final long likeCount;
 
+    private LocalDateTime createdAt;
+
     @QueryProjection
     public ReadReviewQueryDto(User reviewer, UserFollow userFollow, Review review) {
         this.reviewerId = reviewer.getId();
@@ -35,5 +38,6 @@ public class ReadReviewQueryDto {
         this.content = review.getContent();
         this.rating = review.getRating();
         this.likeCount = review.getLikeCount();
+        this.createdAt = review.getCreatedAt();
     }
 }

--- a/src/main/java/com/cvsgo/dto/review/ReadReviewQueryDto.java
+++ b/src/main/java/com/cvsgo/dto/review/ReadReviewQueryDto.java
@@ -26,7 +26,7 @@ public class ReadReviewQueryDto {
 
     private final long likeCount;
 
-    private LocalDateTime createdAt;
+    private final LocalDateTime createdAt;
 
     @QueryProjection
     public ReadReviewQueryDto(User reviewer, UserFollow userFollow, Review review) {

--- a/src/main/java/com/cvsgo/dto/review/ReadReviewQueryDto.java
+++ b/src/main/java/com/cvsgo/dto/review/ReadReviewQueryDto.java
@@ -1,0 +1,36 @@
+package com.cvsgo.dto.review;
+
+import com.cvsgo.entity.Review;
+import com.cvsgo.entity.User;
+import com.cvsgo.entity.UserFollow;
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Getter;
+
+@Getter
+public class ReadReviewQueryDto {
+
+    private final long reviewerId;
+
+    private final long reviewId;
+
+    private final String reviewerNickname;
+
+    private final boolean isFollowing;
+
+    private final String content;
+
+    private final int rating;
+
+    private final long likeCount;
+
+    @QueryProjection
+    public ReadReviewQueryDto(User reviewer, UserFollow userFollow, Review review) {
+        this.reviewerId = reviewer.getId();
+        this.reviewId = review.getId();
+        this.reviewerNickname = reviewer.getNickname();
+        this.isFollowing = userFollow != null;
+        this.content = review.getContent();
+        this.rating = review.getRating();
+        this.likeCount = review.getLikeCount();
+    }
+}

--- a/src/main/java/com/cvsgo/dto/review/ReadReviewQueryDto.java
+++ b/src/main/java/com/cvsgo/dto/review/ReadReviewQueryDto.java
@@ -1,8 +1,6 @@
 package com.cvsgo.dto.review;
 
-import com.cvsgo.entity.Review;
 import com.cvsgo.entity.ReviewLike;
-import com.cvsgo.entity.User;
 import com.cvsgo.entity.UserFollow;
 import com.querydsl.core.annotations.QueryProjection;
 import java.time.LocalDateTime;
@@ -32,17 +30,18 @@ public class ReadReviewQueryDto {
     private final LocalDateTime createdAt;
 
     @QueryProjection
-    public ReadReviewQueryDto(User reviewer, UserFollow userFollow, ReviewLike reviewLike,
-        Review review) {
-        this.reviewerId = reviewer.getId();
-        this.reviewId = review.getId();
-        this.reviewerNickname = reviewer.getNickname();
-        this.reviewerProfileImageUrl = reviewer.getProfileImageUrl();
+    public ReadReviewQueryDto(long reviewerId, long reviewId, String reviewerNickname,
+        String reviewerProfileImageUrl, UserFollow userFollow, String content, int rating,
+        ReviewLike reviewLike, long likeCount, LocalDateTime createdAt) {
+        this.reviewerId = reviewerId;
+        this.reviewId = reviewId;
+        this.reviewerNickname = reviewerNickname;
+        this.reviewerProfileImageUrl = reviewerProfileImageUrl;
         this.isFollowing = userFollow != null;
+        this.content = content;
+        this.rating = rating;
         this.isReviewLiked = reviewLike != null;
-        this.content = review.getContent();
-        this.rating = review.getRating();
-        this.likeCount = review.getLikeCount();
-        this.createdAt = review.getCreatedAt();
+        this.likeCount = likeCount;
+        this.createdAt = createdAt;
     }
 }

--- a/src/main/java/com/cvsgo/dto/review/ReadReviewQueryDto.java
+++ b/src/main/java/com/cvsgo/dto/review/ReadReviewQueryDto.java
@@ -15,6 +15,8 @@ public class ReadReviewQueryDto {
 
     private final String reviewerNickname;
 
+    private final String reviewerProfileImageUrl;
+
     private final boolean isFollowing;
 
     private final String content;
@@ -28,6 +30,7 @@ public class ReadReviewQueryDto {
         this.reviewerId = reviewer.getId();
         this.reviewId = review.getId();
         this.reviewerNickname = reviewer.getNickname();
+        this.reviewerProfileImageUrl = reviewer.getProfileImageUrl();
         this.isFollowing = userFollow != null;
         this.content = review.getContent();
         this.rating = review.getRating();

--- a/src/main/java/com/cvsgo/dto/review/ReadReviewQueryDto.java
+++ b/src/main/java/com/cvsgo/dto/review/ReadReviewQueryDto.java
@@ -1,6 +1,7 @@
 package com.cvsgo.dto.review;
 
 import com.cvsgo.entity.Review;
+import com.cvsgo.entity.ReviewLike;
 import com.cvsgo.entity.User;
 import com.cvsgo.entity.UserFollow;
 import com.querydsl.core.annotations.QueryProjection;
@@ -24,17 +25,21 @@ public class ReadReviewQueryDto {
 
     private final int rating;
 
+    private final boolean isReviewLiked;
+
     private final long likeCount;
 
     private final LocalDateTime createdAt;
 
     @QueryProjection
-    public ReadReviewQueryDto(User reviewer, UserFollow userFollow, Review review) {
+    public ReadReviewQueryDto(User reviewer, UserFollow userFollow, ReviewLike reviewLike,
+        Review review) {
         this.reviewerId = reviewer.getId();
         this.reviewId = review.getId();
         this.reviewerNickname = reviewer.getNickname();
         this.reviewerProfileImageUrl = reviewer.getProfileImageUrl();
         this.isFollowing = userFollow != null;
+        this.isReviewLiked = reviewLike != null;
         this.content = review.getContent();
         this.rating = review.getRating();
         this.likeCount = review.getLikeCount();

--- a/src/main/java/com/cvsgo/dto/review/ReadReviewRequestDto.java
+++ b/src/main/java/com/cvsgo/dto/review/ReadReviewRequestDto.java
@@ -1,0 +1,20 @@
+package com.cvsgo.dto.review;
+
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class ReadReviewRequestDto {
+
+    private final List<Long> tagIds;
+
+    private final List<Integer> ratings;
+
+    private final ReviewSortBy sortBy;
+
+    public ReadReviewRequestDto(List<Long> tagIds, List<Integer> ratings, ReviewSortBy sortBy) {
+        this.tagIds = tagIds;
+        this.ratings = ratings;
+        this.sortBy = sortBy;
+    }
+}

--- a/src/main/java/com/cvsgo/dto/review/ReadReviewResponseDto.java
+++ b/src/main/java/com/cvsgo/dto/review/ReadReviewResponseDto.java
@@ -1,0 +1,70 @@
+package com.cvsgo.dto.review;
+
+import com.cvsgo.entity.ReviewImage;
+import com.cvsgo.entity.User;
+import com.cvsgo.entity.UserTag;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ReadReviewResponseDto {
+
+    private final Long reviewId;
+
+    private final Long reviewerId;
+
+    private final String reviewerNickname;
+
+    private final Boolean isFollowingUser;
+
+    private final Boolean isMe;
+
+    private final String reviewContent;
+
+    private final Integer reviewRating;
+
+    private final Long reviewLikeCount;
+
+    private final List<String> reviewerTags;
+
+    private final List<String> reviewImages;
+
+    @Builder
+    private ReadReviewResponseDto(Long reviewId, Long reviewerId, String reviewerNickname,
+        Boolean isFollowingUser, String reviewContent, Integer reviewRating, Long reviewLikeCount,
+        boolean isMe, List<String> tags, List<String> reviewImages) {
+        this.reviewId = reviewId;
+        this.reviewerId = reviewerId;
+        this.reviewerNickname = reviewerNickname;
+        this.isFollowingUser = isFollowingUser;
+        this.isMe = isMe;
+        this.reviewContent = reviewContent;
+        this.reviewRating = reviewRating;
+        this.reviewLikeCount = reviewLikeCount;
+        this.reviewerTags = tags;
+        this.reviewImages = reviewImages;
+    }
+
+    public static ReadReviewResponseDto of(ReadReviewQueryDto queryDto, User loginUser,
+        List<ReviewImage> reviewImages, List<UserTag> userTags) {
+        List<String> reviewImageUrls =
+            reviewImages != null ? reviewImages.stream().map(ReviewImage::getImageUrl).toList()
+                : List.of();
+        List<String> tags =
+            userTags != null ? userTags.stream().map(userTag -> userTag.getTag().getName()).toList()
+                : List.of();
+        return ReadReviewResponseDto.builder()
+            .reviewContent(queryDto.getContent())
+            .reviewId(queryDto.getReviewId())
+            .reviewerId(queryDto.getReviewerId())
+            .reviewRating(queryDto.getRating())
+            .reviewLikeCount(queryDto.getLikeCount())
+            .isFollowingUser(queryDto.isFollowing())
+            .isMe(loginUser != null && loginUser.getId() == queryDto.getReviewerId())
+            .reviewerNickname(queryDto.getReviewerNickname())
+            .reviewImages(reviewImageUrls)
+            .tags(tags)
+            .build();
+    }
+}

--- a/src/main/java/com/cvsgo/dto/review/ReadReviewResponseDto.java
+++ b/src/main/java/com/cvsgo/dto/review/ReadReviewResponseDto.java
@@ -3,6 +3,8 @@ package com.cvsgo.dto.review;
 import com.cvsgo.entity.ReviewImage;
 import com.cvsgo.entity.User;
 import com.cvsgo.entity.UserTag;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
@@ -32,11 +34,14 @@ public class ReadReviewResponseDto {
 
     private final List<String> reviewImages;
 
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
+    private final LocalDateTime createdAt;
+
     @Builder
     private ReadReviewResponseDto(Long reviewId, Long reviewerId, String reviewerNickname,
         String reviewerProfileImageUrl, Boolean isFollowingUser, String reviewContent,
         Integer reviewRating, Long reviewLikeCount, boolean isMe, List<String> tags,
-        List<String> reviewImages) {
+        List<String> reviewImages, LocalDateTime createdAt) {
         this.reviewId = reviewId;
         this.reviewerId = reviewerId;
         this.reviewerNickname = reviewerNickname;
@@ -48,6 +53,7 @@ public class ReadReviewResponseDto {
         this.reviewLikeCount = reviewLikeCount;
         this.reviewerTags = tags;
         this.reviewImages = reviewImages;
+        this.createdAt = createdAt;
     }
 
     public static ReadReviewResponseDto of(ReadReviewQueryDto queryDto, User loginUser,
@@ -69,6 +75,7 @@ public class ReadReviewResponseDto {
             .reviewerNickname(queryDto.getReviewerNickname())
             .reviewerProfileImageUrl(queryDto.getReviewerProfileImageUrl())
             .reviewImages(reviewImageUrls)
+            .createdAt(queryDto.getCreatedAt())
             .tags(tags)
             .build();
     }

--- a/src/main/java/com/cvsgo/dto/review/ReadReviewResponseDto.java
+++ b/src/main/java/com/cvsgo/dto/review/ReadReviewResponseDto.java
@@ -28,6 +28,8 @@ public class ReadReviewResponseDto {
 
     private final Integer reviewRating;
 
+    private final Boolean isReviewLiked;
+
     private final Long reviewLikeCount;
 
     private final List<String> reviewerTags;
@@ -40,8 +42,8 @@ public class ReadReviewResponseDto {
     @Builder
     private ReadReviewResponseDto(Long reviewId, Long reviewerId, String reviewerNickname,
         String reviewerProfileImageUrl, Boolean isFollowingUser, String reviewContent,
-        Integer reviewRating, Long reviewLikeCount, boolean isMe, List<String> tags,
-        List<String> reviewImages, LocalDateTime createdAt) {
+        Integer reviewRating, Boolean isReviewLiked, Long reviewLikeCount, boolean isMe,
+        List<String> tags, List<String> reviewImages, LocalDateTime createdAt) {
         this.reviewId = reviewId;
         this.reviewerId = reviewerId;
         this.reviewerNickname = reviewerNickname;
@@ -50,6 +52,7 @@ public class ReadReviewResponseDto {
         this.isMe = isMe;
         this.reviewContent = reviewContent;
         this.reviewRating = reviewRating;
+        this.isReviewLiked = isReviewLiked;
         this.reviewLikeCount = reviewLikeCount;
         this.reviewerTags = tags;
         this.reviewImages = reviewImages;
@@ -69,6 +72,7 @@ public class ReadReviewResponseDto {
             .reviewId(queryDto.getReviewId())
             .reviewerId(queryDto.getReviewerId())
             .reviewRating(queryDto.getRating())
+            .isReviewLiked(queryDto.isReviewLiked())
             .reviewLikeCount(queryDto.getLikeCount())
             .isFollowingUser(queryDto.isFollowing())
             .isMe(loginUser != null && loginUser.getId() == queryDto.getReviewerId())

--- a/src/main/java/com/cvsgo/dto/review/ReadReviewResponseDto.java
+++ b/src/main/java/com/cvsgo/dto/review/ReadReviewResponseDto.java
@@ -16,6 +16,8 @@ public class ReadReviewResponseDto {
 
     private final String reviewerNickname;
 
+    private final String reviewerProfileImageUrl;
+
     private final Boolean isFollowingUser;
 
     private final Boolean isMe;
@@ -32,11 +34,13 @@ public class ReadReviewResponseDto {
 
     @Builder
     private ReadReviewResponseDto(Long reviewId, Long reviewerId, String reviewerNickname,
-        Boolean isFollowingUser, String reviewContent, Integer reviewRating, Long reviewLikeCount,
-        boolean isMe, List<String> tags, List<String> reviewImages) {
+        String reviewerProfileImageUrl, Boolean isFollowingUser, String reviewContent,
+        Integer reviewRating, Long reviewLikeCount, boolean isMe, List<String> tags,
+        List<String> reviewImages) {
         this.reviewId = reviewId;
         this.reviewerId = reviewerId;
         this.reviewerNickname = reviewerNickname;
+        this.reviewerProfileImageUrl = reviewerProfileImageUrl;
         this.isFollowingUser = isFollowingUser;
         this.isMe = isMe;
         this.reviewContent = reviewContent;
@@ -63,6 +67,7 @@ public class ReadReviewResponseDto {
             .isFollowingUser(queryDto.isFollowing())
             .isMe(loginUser != null && loginUser.getId() == queryDto.getReviewerId())
             .reviewerNickname(queryDto.getReviewerNickname())
+            .reviewerProfileImageUrl(queryDto.getReviewerProfileImageUrl())
             .reviewImages(reviewImageUrls)
             .tags(tags)
             .build();

--- a/src/main/java/com/cvsgo/entity/Review.java
+++ b/src/main/java/com/cvsgo/entity/Review.java
@@ -3,6 +3,7 @@ package com.cvsgo.entity;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -33,13 +34,16 @@ public class Review extends BaseTimeEntity {
     @Column(columnDefinition = "TEXT")
     private String content;
 
+    @NotNull
     private Integer rating;
 
-    @ManyToOne
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
 
-    @ManyToOne
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "product_id")
     private Product product;
 

--- a/src/main/java/com/cvsgo/entity/ReviewImage.java
+++ b/src/main/java/com/cvsgo/entity/ReviewImage.java
@@ -1,6 +1,7 @@
 package com.cvsgo.entity;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -24,7 +25,7 @@ public class ReviewImage extends BaseTimeEntity {
     private String imageUrl;
 
     @NotNull
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "review_id")
     private Review review;
 

--- a/src/main/java/com/cvsgo/entity/ReviewLike.java
+++ b/src/main/java/com/cvsgo/entity/ReviewLike.java
@@ -1,6 +1,7 @@
 package com.cvsgo.entity;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -23,11 +24,11 @@ public class ReviewLike extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "review_id")
     private Review review;
 

--- a/src/main/java/com/cvsgo/entity/UserFollow.java
+++ b/src/main/java/com/cvsgo/entity/UserFollow.java
@@ -9,6 +9,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -30,6 +31,7 @@ public class UserFollow extends BaseTimeEntity {
     @JoinColumn(name = "follower_id")
     private User follower;
 
+    @Builder
     public UserFollow(Long id, User following, User follower) {
         this.id = id;
         this.following = following;

--- a/src/main/java/com/cvsgo/entity/UserFollow.java
+++ b/src/main/java/com/cvsgo/entity/UserFollow.java
@@ -1,6 +1,7 @@
 package com.cvsgo.entity;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -23,11 +24,11 @@ public class UserFollow extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "following_id")
     private User following;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "follower_id")
     private User follower;
 

--- a/src/main/java/com/cvsgo/interceptor/AuthInterceptor.java
+++ b/src/main/java/com/cvsgo/interceptor/AuthInterceptor.java
@@ -5,7 +5,9 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
 import org.springframework.web.servlet.HandlerInterceptor;
 
 import static com.cvsgo.exception.ExceptionConstants.UNAUTHORIZED_USER;
@@ -17,9 +19,16 @@ public class AuthInterceptor implements HandlerInterceptor {
 
     private final AuthService authService;
 
+    AntPathMatcher pathMatcher = new AntPathMatcher();
+
     @Override
-    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response,
+        Object handler) throws Exception {
         String authorizationHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if (pathMatcher.match("/api/products/*/reviews", request.getRequestURI())
+            && HttpMethod.GET.matches(request.getMethod())) {
+            return true;
+        }
         if (authorizationHeader == null) {
             throw UNAUTHORIZED_USER;
         }

--- a/src/main/java/com/cvsgo/interceptor/AuthInterceptor.java
+++ b/src/main/java/com/cvsgo/interceptor/AuthInterceptor.java
@@ -19,7 +19,7 @@ public class AuthInterceptor implements HandlerInterceptor {
 
     private final AuthService authService;
 
-    AntPathMatcher pathMatcher = new AntPathMatcher();
+    private final AntPathMatcher pathMatcher = new AntPathMatcher();
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response,

--- a/src/main/java/com/cvsgo/repository/ReviewCustomRepository.java
+++ b/src/main/java/com/cvsgo/repository/ReviewCustomRepository.java
@@ -14,4 +14,6 @@ public interface ReviewCustomRepository {
     List<ReadReviewQueryDto> findAllByFilter(User loginUser, Long productId,
         ReadReviewRequestDto filter, Pageable pageable);
 
+    Long countByProductIdAndFilter(Long productId, ReadReviewRequestDto filter);
+
 }

--- a/src/main/java/com/cvsgo/repository/ReviewCustomRepository.java
+++ b/src/main/java/com/cvsgo/repository/ReviewCustomRepository.java
@@ -1,5 +1,7 @@
 package com.cvsgo.repository;
 
+import com.cvsgo.dto.review.ReadReviewQueryDto;
+import com.cvsgo.dto.review.ReadReviewRequestDto;
 import com.cvsgo.dto.review.SearchReviewQueryDto;
 import com.cvsgo.dto.review.SearchReviewRequestDto;
 import com.cvsgo.entity.User;
@@ -8,5 +10,8 @@ import org.springframework.data.domain.Pageable;
 
 public interface ReviewCustomRepository {
     List<SearchReviewQueryDto> searchByFilter(User user, SearchReviewRequestDto request, Pageable pageable);
+
+    List<ReadReviewQueryDto> findAllByFilter(User loginUser, Long productId,
+        ReadReviewRequestDto filter, Pageable pageable);
 
 }

--- a/src/main/java/com/cvsgo/repository/ReviewCustomRepository.java
+++ b/src/main/java/com/cvsgo/repository/ReviewCustomRepository.java
@@ -11,7 +11,7 @@ import org.springframework.data.domain.Pageable;
 public interface ReviewCustomRepository {
     List<SearchReviewQueryDto> searchByFilter(User user, SearchReviewRequestDto request, Pageable pageable);
 
-    List<ReadReviewQueryDto> findAllByFilter(User loginUser, Long productId,
+    List<ReadReviewQueryDto> findAllByProductIdAndFilter(User loginUser, Long productId,
         ReadReviewRequestDto filter, Pageable pageable);
 
     Long countByProductIdAndFilter(Long productId, ReadReviewRequestDto filter);

--- a/src/main/java/com/cvsgo/repository/ReviewCustomRepositoryImpl.java
+++ b/src/main/java/com/cvsgo/repository/ReviewCustomRepositoryImpl.java
@@ -64,7 +64,7 @@ public class ReviewCustomRepositoryImpl implements ReviewCustomRepository {
             .fetch();
     }
 
-    public List<ReadReviewQueryDto> findAllByFilter(User loginUser, Long productId,
+    public List<ReadReviewQueryDto> findAllByProductIdAndFilter(User loginUser, Long productId,
         ReadReviewRequestDto filter, Pageable pageable) {
         return queryFactory.select(new QReadReviewQueryDto(user, userFollow, reviewLike, review))
             .from(review)

--- a/src/main/java/com/cvsgo/repository/ReviewCustomRepositoryImpl.java
+++ b/src/main/java/com/cvsgo/repository/ReviewCustomRepositoryImpl.java
@@ -84,6 +84,19 @@ public class ReviewCustomRepositoryImpl implements ReviewCustomRepository {
             .fetch();
     }
 
+    public Long countByProductIdAndFilter(Long productId, ReadReviewRequestDto filter) {
+        return queryFactory.select(review.count())
+            .from(review)
+            .join(user).on(user.eq(review.user))
+            .join(product).on(review.product.eq(product))
+            .where(
+                review.product.id.eq(productId),
+                ratingIn(filter.getRatings()),
+                userIn(filter.getTagIds())
+            )
+            .fetchOne();
+    }
+
     private OrderSpecifier<?> sortBy(ReviewSortBy sortBy) {
         return sortBy != null ?
             switch (sortBy) {

--- a/src/main/java/com/cvsgo/repository/ReviewCustomRepositoryImpl.java
+++ b/src/main/java/com/cvsgo/repository/ReviewCustomRepositoryImpl.java
@@ -66,12 +66,13 @@ public class ReviewCustomRepositoryImpl implements ReviewCustomRepository {
 
     public List<ReadReviewQueryDto> findAllByFilter(User loginUser, Long productId,
         ReadReviewRequestDto filter, Pageable pageable) {
-        return queryFactory.select(new QReadReviewQueryDto(user, userFollow, review))
+        return queryFactory.select(new QReadReviewQueryDto(user, userFollow, reviewLike, review))
             .from(review)
             .join(user).on(user.eq(review.user))
             .join(product).on(review.product.eq(product))
             .leftJoin(userFollow)
             .on(review.user.eq(userFollow.following).and(userFollowingEq(loginUser)))
+            .leftJoin(reviewLike).on(reviewLike.review.eq(review).and(reviewLikeUserEq(loginUser)))
             .where(
                 review.product.id.eq(productId),
                 ratingIn(filter.getRatings()),

--- a/src/main/java/com/cvsgo/repository/ReviewCustomRepositoryImpl.java
+++ b/src/main/java/com/cvsgo/repository/ReviewCustomRepositoryImpl.java
@@ -101,7 +101,7 @@ public class ReviewCustomRepositoryImpl implements ReviewCustomRepository {
     }
 
     BooleanExpression reviewLikeUserEq(User user) {
-        return user != null ? reviewLike.user.eq(user) : null;
+        return reviewLike.user.id.eq(user == null ? -1L : user.getId());
     }
 
     private BooleanExpression userFollowingEq(User user) {

--- a/src/main/java/com/cvsgo/repository/ReviewCustomRepositoryImpl.java
+++ b/src/main/java/com/cvsgo/repository/ReviewCustomRepositoryImpl.java
@@ -66,7 +66,17 @@ public class ReviewCustomRepositoryImpl implements ReviewCustomRepository {
 
     public List<ReadReviewQueryDto> findAllByProductIdAndFilter(User loginUser, Long productId,
         ReadReviewRequestDto filter, Pageable pageable) {
-        return queryFactory.select(new QReadReviewQueryDto(user, userFollow, reviewLike, review))
+        return queryFactory.select(new QReadReviewQueryDto(
+                user.id,
+                review.id,
+                user.nickname,
+                user.profileImageUrl,
+                userFollow,
+                review.content,
+                review.rating,
+                reviewLike,
+                review.likeCount,
+                review.createdAt))
             .from(review)
             .join(user).on(user.eq(review.user))
             .join(product).on(review.product.eq(product))

--- a/src/main/java/com/cvsgo/repository/ReviewCustomRepositoryImpl.java
+++ b/src/main/java/com/cvsgo/repository/ReviewCustomRepositoryImpl.java
@@ -75,18 +75,12 @@ public class ReviewCustomRepositoryImpl implements ReviewCustomRepository {
             .where(
                 review.product.id.eq(productId),
                 ratingIn(filter.getRatings()),
-                userTagIn(filter.getTagIds())
+                userIn(filter.getTagIds())
             )
             .orderBy(sortBy(filter.getSortBy()))
             .offset(pageable.getOffset())
             .limit(pageable.getPageSize())
             .fetch();
-    }
-
-    private BooleanExpression userTagIn(List<Long> tagIds) {
-        return tagIds != null && !tagIds.isEmpty() ?
-            user.in(selectDistinct(userTag.user).from(userTag).where(userTag.tag.id.in(tagIds)))
-            : null;
     }
 
     private OrderSpecifier<?> sortBy(ReviewSortBy sortBy) {

--- a/src/main/java/com/cvsgo/repository/UserTagRepository.java
+++ b/src/main/java/com/cvsgo/repository/UserTagRepository.java
@@ -11,4 +11,7 @@ public interface UserTagRepository extends JpaRepository<UserTag, Long> {
     @EntityGraph(attributePaths = "tag")
     List<UserTag> findByUserIn(List<User> users);
 
+    @EntityGraph(attributePaths = {"user", "tag"})
+    List<UserTag> findByUserIdIn(List<Long> userIds);
+
 }

--- a/src/main/java/com/cvsgo/service/ReviewService.java
+++ b/src/main/java/com/cvsgo/service/ReviewService.java
@@ -159,8 +159,8 @@ public class ReviewService {
             }
         }
 
-        List<ReadReviewQueryDto> reviews = reviewRepository.findAllByFilter(user, productId,
-            request, pageable);
+        List<ReadReviewQueryDto> reviews = reviewRepository.findAllByProductIdAndFilter(user,
+            productId, request, pageable);
 
         Long totalCount = reviewRepository.countByProductIdAndFilter(productId, request);
 

--- a/src/main/java/com/cvsgo/service/ReviewService.java
+++ b/src/main/java/com/cvsgo/service/ReviewService.java
@@ -148,7 +148,7 @@ public class ReviewService {
      * @throws ForbiddenUserException 정회원이 아닌 회원이 0페이지가 아닌 다른 페이지를 조회하는 경우
      */
     @Transactional(readOnly = true)
-    public Page<ReadReviewResponseDto> getProductReviewList(User user, Long productId,
+    public Page<ReadReviewResponseDto> readProductReviewList(User user, Long productId,
         ReadReviewRequestDto request, Pageable pageable) {
 
         if (user == null || user.getRole() != Role.REGULAR) {

--- a/src/main/java/com/cvsgo/service/ReviewService.java
+++ b/src/main/java/com/cvsgo/service/ReviewService.java
@@ -165,18 +165,15 @@ public class ReviewService {
         Long totalCount = reviewRepository.countByProductIdAndFilter(productId, request);
 
         Map<Long, List<ReviewImage>> reviewImagesByReview = reviewImageRepository.findByReviewIdIn(
-                reviews.stream().map(
-                    ReadReviewQueryDto::getReviewId).distinct().toList())
-            .stream()
+                reviews.stream().map(ReadReviewQueryDto::getReviewId).distinct().toList()).stream()
             .collect(Collectors.groupingBy(reviewImage -> reviewImage.getReview().getId()));
 
-        Map<Long, List<UserTag>> userTagsByUser =
-            userTagRepository.findByUserIdIn(
-                    reviews.stream().map(ReadReviewQueryDto::getReviewerId).distinct().toList())
-                .stream().collect(Collectors.groupingBy(userTag -> userTag.getUser().getId()));
+        Map<Long, List<UserTag>> userTagsByUser = userTagRepository.findByUserIdIn(
+                reviews.stream().map(ReadReviewQueryDto::getReviewerId).distinct().toList()).stream()
+            .collect(Collectors.groupingBy(userTag -> userTag.getUser().getId()));
 
-        List<ReadReviewResponseDto> results = reviews.stream()
-            .map(reviewDto -> ReadReviewResponseDto.of(reviewDto, user,
+        List<ReadReviewResponseDto> results = reviews.stream().map(
+            reviewDto -> ReadReviewResponseDto.of(reviewDto, user,
                 reviewImagesByReview.get(reviewDto.getReviewId()),
                 userTagsByUser.get(reviewDto.getReviewerId()))).toList();
 

--- a/src/main/java/com/cvsgo/service/ReviewService.java
+++ b/src/main/java/com/cvsgo/service/ReviewService.java
@@ -134,6 +134,15 @@ public class ReviewService {
             ).toList();
     }
 
+    /**
+     * 특정 상품의 리뷰 목록을 조회합니다.
+     *
+     * @param user      현재 로그인한 사용자
+     * @param productId 상품 ID
+     * @param request   필터 정보
+     * @param pageable  페이지 정보
+     * @return 리뷰 목록
+     */
     @Transactional(readOnly = true)
     public List<ReadReviewResponseDto> getProductReviewList(User user, Long productId,
         ReadReviewRequestDto request, Pageable pageable) {

--- a/src/main/java/com/cvsgo/service/ReviewService.java
+++ b/src/main/java/com/cvsgo/service/ReviewService.java
@@ -28,6 +28,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import com.cvsgo.exception.product.NotFoundProductException;
 import com.cvsgo.exception.auth.UnauthorizedUserException;
+import com.cvsgo.exception.user.ForbiddenUserException;
 
 import java.io.IOException;
 import java.util.List;
@@ -142,6 +143,7 @@ public class ReviewService {
      * @param request   필터 정보
      * @param pageable  페이지 정보
      * @return 리뷰 목록
+     * @throws ForbiddenUserException 정회원이 아닌 회원이 0페이지가 아닌 다른 페이지를 조회하는 경우
      */
     @Transactional(readOnly = true)
     public List<ReadReviewResponseDto> getProductReviewList(User user, Long productId,

--- a/src/test/java/com/cvsgo/controller/ReviewControllerTest.java
+++ b/src/test/java/com/cvsgo/controller/ReviewControllerTest.java
@@ -188,7 +188,7 @@ class ReviewControllerTest {
         ReadReviewRequestDto requestDto = new ReadReviewRequestDto(List.of(1L, 2L, 3L), List.of(4, 5), ReviewSortBy.LATEST);
         User reviewer = User.builder().id(1L).userId("abc@naver.com").role(Role.REGULAR).nickname("닉네임").build();
         Review review = Review.builder().id(1L).rating(4).content("맛있어요").user(reviewer).imageUrls(List.of()).build();
-        ReadReviewQueryDto readReviewQueryDto = new ReadReviewQueryDto(reviewer, null, review);
+        ReadReviewQueryDto readReviewQueryDto = new ReadReviewQueryDto(reviewer, null, null, review);
         ReadReviewResponseDto responseDto = ReadReviewResponseDto.of(readReviewQueryDto, reviewer,
             List.of(reviewImage1, reviewImage2), List.of(userTag1, userTag2, userTag3));
 

--- a/src/test/java/com/cvsgo/controller/ReviewControllerTest.java
+++ b/src/test/java/com/cvsgo/controller/ReviewControllerTest.java
@@ -186,10 +186,16 @@ class ReviewControllerTest {
     @Test
     @DisplayName("특정 상품의 리뷰 목록 조회에 성공하면 HTTP 200을 응답한다.")
     void respond_200_when_success_to_read_product_reviews() throws Exception {
-        ReadReviewRequestDto requestDto = new ReadReviewRequestDto(List.of(1L, 2L, 3L), List.of(4, 5), ReviewSortBy.LATEST);
-        User reviewer = User.builder().id(1L).userId("abc@naver.com").role(Role.REGULAR).nickname("닉네임").build();
-        Review review = Review.builder().id(1L).rating(4).content("맛있어요").user(reviewer).imageUrls(List.of()).build();
-        ReadReviewQueryDto readReviewQueryDto = new ReadReviewQueryDto(reviewer, null, null, review);
+        ReadReviewRequestDto requestDto = new ReadReviewRequestDto(List.of(1L, 2L, 3L),
+            List.of(4, 5), ReviewSortBy.LATEST);
+        User reviewer = User.builder().id(1L).userId("abc@naver.com").role(Role.REGULAR)
+            .nickname("닉네임").build();
+        Review review = Review.builder().id(1L).rating(4).content("맛있어요").user(reviewer)
+            .imageUrls(List.of()).build();
+        ReadReviewQueryDto readReviewQueryDto = new ReadReviewQueryDto(reviewer.getId(),
+            review.getId(), reviewer.getNickname(), reviewer.getProfileImageUrl(), null,
+            review.getContent(), review.getRating(), null, review.getLikeCount(),
+            LocalDateTime.now());
         ReadReviewResponseDto responseDto = ReadReviewResponseDto.of(readReviewQueryDto, reviewer,
             List.of(reviewImage1, reviewImage2), List.of(userTag1, userTag2, userTag3));
 

--- a/src/test/java/com/cvsgo/controller/ReviewControllerTest.java
+++ b/src/test/java/com/cvsgo/controller/ReviewControllerTest.java
@@ -193,7 +193,7 @@ class ReviewControllerTest {
         ReadReviewResponseDto responseDto = ReadReviewResponseDto.of(readReviewQueryDto, reviewer,
             List.of(reviewImage1, reviewImage2), List.of(userTag1, userTag2, userTag3));
 
-        given(reviewService.getProductReviewList(any(), anyLong(), any(), any()))
+        given(reviewService.readProductReviewList(any(), anyLong(), any(), any()))
             .willReturn(new PageImpl<>(List.of(responseDto)));
 
         mockMvc.perform(get(PRODUCT_REVIEW_API_PATH, 1)
@@ -230,7 +230,7 @@ class ReviewControllerTest {
     @DisplayName("권한이 없는 사용자가 특정 상품 리뷰를 조회하면 HTTP 403을 응답한다.")
     void respond_403_when_associate_member_try_to_read_product_reviews() throws Exception {
 
-        given(reviewService.getProductReviewList(any(), anyLong(), any(), any()))
+        given(reviewService.readProductReviewList(any(), anyLong(), any(), any()))
             .willThrow(FORBIDDEN_USER);
 
         mockMvc.perform(get(PRODUCT_REVIEW_API_PATH, 1)

--- a/src/test/java/com/cvsgo/controller/ReviewControllerTest.java
+++ b/src/test/java/com/cvsgo/controller/ReviewControllerTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.restdocs.RestDocumentationContextProvider;
@@ -193,7 +194,7 @@ class ReviewControllerTest {
             List.of(reviewImage1, reviewImage2), List.of(userTag1, userTag2, userTag3));
 
         given(reviewService.getProductReviewList(any(), anyLong(), any(), any()))
-            .willReturn(List.of(responseDto));
+            .willReturn(new PageImpl<>(List.of(responseDto)));
 
         mockMvc.perform(get(PRODUCT_REVIEW_API_PATH, 1)
                 .content(objectMapper.writeValueAsString(requestDto))
@@ -208,19 +209,19 @@ class ReviewControllerTest {
                     fieldWithPath("ratings").type(JsonFieldType.ARRAY).description("별점 목록").optional()
                 ),
                 relaxedResponseFields(
-                    fieldWithPath("data[].reviewId").type(JsonFieldType.NUMBER).description("리뷰 ID"),
-                    fieldWithPath("data[].reviewerId").type(JsonFieldType.NUMBER).description("리뷰 작성자 ID"),
-                    fieldWithPath("data[].reviewerNickname").type(JsonFieldType.STRING).description("리뷰 작성자 닉네임"),
-                    fieldWithPath("data[].reviewerProfileImageUrl").type(JsonFieldType.STRING).description("리뷰 작성자 프로필 이미지 URL").optional(),
-                    fieldWithPath("data[].reviewerTags").type(JsonFieldType.ARRAY).description("리뷰 작성자의 태그 목록"),
-                    fieldWithPath("data[].reviewLikeCount").type(JsonFieldType.NUMBER).description("리뷰 좋아요 개수"),
-                    fieldWithPath("data[].reviewRating").type(JsonFieldType.NUMBER).description("리뷰 별점"),
-                    fieldWithPath("data[].reviewContent").type(JsonFieldType.STRING).description("리뷰 내용"),
-                    fieldWithPath("data[].isReviewLiked").type(JsonFieldType.BOOLEAN).description("사용자의 리뷰 좋아요 여부"),
-                    fieldWithPath("data[].isFollowingUser").type(JsonFieldType.BOOLEAN).description("사용자가 리뷰 작성자를 팔로우하는지 여부"),
-                    fieldWithPath("data[].isMe").type(JsonFieldType.BOOLEAN).description("로그인한 사용자가 리뷰 작성자인지 여부"),
-                    fieldWithPath("data[].reviewImages").type(JsonFieldType.ARRAY).description("리뷰 이미지 URL 목록"),
-                    fieldWithPath("data[].createdAt").type(JsonFieldType.STRING).description("리뷰 생성 시간").optional()
+                    fieldWithPath("data.content[].reviewId").type(JsonFieldType.NUMBER).description("리뷰 ID"),
+                    fieldWithPath("data.content[].reviewerId").type(JsonFieldType.NUMBER).description("리뷰 작성자 ID"),
+                    fieldWithPath("data.content[].reviewerNickname").type(JsonFieldType.STRING).description("리뷰 작성자 닉네임"),
+                    fieldWithPath("data.content[].reviewerProfileImageUrl").type(JsonFieldType.STRING).description("리뷰 작성자 프로필 이미지 URL").optional(),
+                    fieldWithPath("data.content[].reviewerTags").type(JsonFieldType.ARRAY).description("리뷰 작성자의 태그 목록"),
+                    fieldWithPath("data.content[].reviewLikeCount").type(JsonFieldType.NUMBER).description("리뷰 좋아요 개수"),
+                    fieldWithPath("data.content[].reviewRating").type(JsonFieldType.NUMBER).description("리뷰 별점"),
+                    fieldWithPath("data.content[].reviewContent").type(JsonFieldType.STRING).description("리뷰 내용"),
+                    fieldWithPath("data.content[].isReviewLiked").type(JsonFieldType.BOOLEAN).description("사용자의 리뷰 좋아요 여부"),
+                    fieldWithPath("data.content[].isFollowingUser").type(JsonFieldType.BOOLEAN).description("사용자가 리뷰 작성자를 팔로우하는지 여부"),
+                    fieldWithPath("data.content[].isMe").type(JsonFieldType.BOOLEAN).description("로그인한 사용자가 리뷰 작성자인지 여부"),
+                    fieldWithPath("data.content[].reviewImages").type(JsonFieldType.ARRAY).description("리뷰 이미지 URL 목록"),
+                    fieldWithPath("data.content[].createdAt").type(JsonFieldType.STRING).description("리뷰 생성 시간").optional()
                 )
             ));
     }

--- a/src/test/java/com/cvsgo/controller/ReviewControllerTest.java
+++ b/src/test/java/com/cvsgo/controller/ReviewControllerTest.java
@@ -216,7 +216,7 @@ class ReviewControllerTest {
                     fieldWithPath("data[].reviewLikeCount").type(JsonFieldType.NUMBER).description("리뷰 좋아요 개수"),
                     fieldWithPath("data[].reviewRating").type(JsonFieldType.NUMBER).description("리뷰 별점"),
                     fieldWithPath("data[].reviewContent").type(JsonFieldType.STRING).description("리뷰 내용"),
-                    fieldWithPath("data[].isFollowingUser").type(JsonFieldType.BOOLEAN).description("리뷰 작성자를 사용자가 팔로우하는지 여부"),
+                    fieldWithPath("data[].isFollowingUser").type(JsonFieldType.BOOLEAN).description("사용자가 리뷰 작성자를 팔로우하는지 여부"),
                     fieldWithPath("data[].reviewImages").type(JsonFieldType.ARRAY).description("리뷰 이미지 URL 목록"),
                     fieldWithPath("data[].createdAt").type(JsonFieldType.STRING).description("리뷰 생성 시간").optional()
                 )

--- a/src/test/java/com/cvsgo/controller/ReviewControllerTest.java
+++ b/src/test/java/com/cvsgo/controller/ReviewControllerTest.java
@@ -216,7 +216,9 @@ class ReviewControllerTest {
                     fieldWithPath("data[].reviewLikeCount").type(JsonFieldType.NUMBER).description("리뷰 좋아요 개수"),
                     fieldWithPath("data[].reviewRating").type(JsonFieldType.NUMBER).description("리뷰 별점"),
                     fieldWithPath("data[].reviewContent").type(JsonFieldType.STRING).description("리뷰 내용"),
+                    fieldWithPath("data[].isReviewLiked").type(JsonFieldType.BOOLEAN).description("사용자의 리뷰 좋아요 여부"),
                     fieldWithPath("data[].isFollowingUser").type(JsonFieldType.BOOLEAN).description("사용자가 리뷰 작성자를 팔로우하는지 여부"),
+                    fieldWithPath("data[].isMe").type(JsonFieldType.BOOLEAN).description("로그인한 사용자가 리뷰 작성자인지 여부"),
                     fieldWithPath("data[].reviewImages").type(JsonFieldType.ARRAY).description("리뷰 이미지 URL 목록"),
                     fieldWithPath("data[].createdAt").type(JsonFieldType.STRING).description("리뷰 생성 시간").optional()
                 )

--- a/src/test/java/com/cvsgo/controller/ReviewControllerTest.java
+++ b/src/test/java/com/cvsgo/controller/ReviewControllerTest.java
@@ -2,11 +2,19 @@ package com.cvsgo.controller;
 
 import com.cvsgo.argumentresolver.LoginUserArgumentResolver;
 import com.cvsgo.config.WebConfig;
+import com.cvsgo.dto.review.ReadReviewQueryDto;
+import com.cvsgo.dto.review.ReadReviewRequestDto;
+import com.cvsgo.dto.review.ReadReviewResponseDto;
 import com.cvsgo.dto.review.ReviewSortBy;
 import com.cvsgo.dto.review.SearchReviewRequestDto;
 import com.cvsgo.dto.review.SearchReviewResponseDto;
 import com.cvsgo.dto.review.UpdateReviewRequestDto;
-import com.cvsgo.exception.review.NotFoundReviewException;
+import com.cvsgo.entity.Review;
+import com.cvsgo.entity.ReviewImage;
+import com.cvsgo.entity.Role;
+import com.cvsgo.entity.Tag;
+import com.cvsgo.entity.User;
+import com.cvsgo.entity.UserTag;
 import com.cvsgo.interceptor.AuthInterceptor;
 import com.cvsgo.service.ReviewService;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -33,6 +41,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import static com.cvsgo.ApiDocumentUtils.documentIdentifier;
 import static com.cvsgo.ApiDocumentUtils.getDocumentRequest;
 import static com.cvsgo.ApiDocumentUtils.getDocumentResponse;
+import static com.cvsgo.exception.ExceptionConstants.FORBIDDEN_USER;
 import static org.hamcrest.Matchers.containsString;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -47,14 +56,12 @@ import static org.mockito.BDDMockito.willThrow;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.multipart;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.relaxedResponseFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
-//import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -80,7 +87,7 @@ class ReviewControllerTest {
 
     private final ObjectMapper objectMapper = new ObjectMapper();
 
-    private static final String CREATE_REVIEW_API_PATH = "/api/products/{productId}/reviews";
+    private static final String PRODUCT_REVIEW_API_PATH = "/api/products/{productId}/reviews";
 
     private static final String UPDATE_REVIEW_API_PATH = "/api/reviews/{reviewId}";
 
@@ -105,7 +112,7 @@ class ReviewControllerTest {
         MockMultipartFile image2 = new MockMultipartFile("images", "sample_image2.png",
             MediaType.IMAGE_PNG_VALUE, "image 2".getBytes());
 
-        mockMvc.perform(multipart(CREATE_REVIEW_API_PATH, 1)
+        mockMvc.perform(multipart(PRODUCT_REVIEW_API_PATH, 1)
                 .file(image1)
                 .file(image2)
                 .param("content", "진짜 맛있어요")
@@ -176,6 +183,59 @@ class ReviewControllerTest {
     }
 
     @Test
+    @DisplayName("특정 상품의 리뷰 목록 조회에 성공하면 HTTP 200을 응답한다.")
+    void respond_200_when_success_to_read_product_reviews() throws Exception {
+        ReadReviewRequestDto requestDto = new ReadReviewRequestDto(List.of(1L, 2L, 3L), List.of(4, 5), ReviewSortBy.LATEST);
+        User reviewer = User.builder().id(1L).userId("abc@naver.com").role(Role.REGULAR).nickname("닉네임").build();
+        Review review = Review.builder().id(1L).rating(4).content("맛있어요").user(reviewer).imageUrls(List.of()).build();
+        ReadReviewQueryDto readReviewQueryDto = new ReadReviewQueryDto(reviewer, null, review);
+        ReadReviewResponseDto responseDto = ReadReviewResponseDto.of(readReviewQueryDto, reviewer,
+            List.of(reviewImage1, reviewImage2), List.of(userTag1, userTag2, userTag3));
+
+        given(reviewService.getProductReviewList(any(), anyLong(), any(), any()))
+            .willReturn(List.of(responseDto));
+
+        mockMvc.perform(get(PRODUCT_REVIEW_API_PATH, 1)
+                .content(objectMapper.writeValueAsString(requestDto))
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk()).andDo(print())
+            .andDo(document(documentIdentifier,
+                getDocumentRequest(),
+                getDocumentResponse(),
+                requestFields(
+                    fieldWithPath("sortBy").type(JsonFieldType.STRING).description("정렬 기준").optional(),
+                    fieldWithPath("tagIds").type(JsonFieldType.ARRAY).description("태그 ID 목록").optional(),
+                    fieldWithPath("ratings").type(JsonFieldType.ARRAY).description("별점 목록").optional()
+                ),
+                relaxedResponseFields(
+                    fieldWithPath("data[].reviewId").type(JsonFieldType.NUMBER).description("리뷰 ID"),
+                    fieldWithPath("data[].reviewerId").type(JsonFieldType.NUMBER).description("리뷰 작성자 ID"),
+                    fieldWithPath("data[].reviewerNickname").type(JsonFieldType.STRING).description("리뷰 작성자 닉네임"),
+                    fieldWithPath("data[].reviewerProfileImageUrl").type(JsonFieldType.STRING).description("리뷰 작성자 프로필 이미지 URL").optional(),
+                    fieldWithPath("data[].reviewerTags").type(JsonFieldType.ARRAY).description("리뷰 작성자의 태그 목록"),
+                    fieldWithPath("data[].reviewLikeCount").type(JsonFieldType.NUMBER).description("리뷰 좋아요 개수"),
+                    fieldWithPath("data[].reviewRating").type(JsonFieldType.NUMBER).description("리뷰 별점"),
+                    fieldWithPath("data[].reviewContent").type(JsonFieldType.STRING).description("리뷰 내용"),
+                    fieldWithPath("data[].isFollowingUser").type(JsonFieldType.BOOLEAN).description("리뷰 작성자를 사용자가 팔로우하는지 여부"),
+                    fieldWithPath("data[].reviewImages").type(JsonFieldType.ARRAY).description("리뷰 이미지 URL 목록"),
+                    fieldWithPath("data[].createdAt").type(JsonFieldType.STRING).description("리뷰 생성 시간").optional()
+                )
+            ));
+    }
+
+    @Test
+    @DisplayName("권한이 없는 사용자가 특정 상품 리뷰를 조회하면 HTTP 403을 응답한다.")
+    void respond_403_when_associate_member_try_to_read_product_reviews() throws Exception {
+
+        given(reviewService.getProductReviewList(any(), anyLong(), any(), any()))
+            .willThrow(FORBIDDEN_USER);
+
+        mockMvc.perform(get(PRODUCT_REVIEW_API_PATH, 1)
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isForbidden()).andDo(print());
+    }
+
+    @Test
     @DisplayName("리뷰 수정에 성공하면 HTTP 200을 응답한다.")
     void respond_200_when_success_to_update_review() throws Exception {
         UpdateReviewRequestDto requestDto = new UpdateReviewRequestDto(5, "맛있어요",
@@ -204,7 +264,7 @@ class ReviewControllerTest {
     @ValueSource(ints = {0, 6, 7, 8, 9, 10, 100})
     void respond_400_when_rating_is_not_range_1_to_5(Integer rating) throws Exception {
 
-        mockMvc.perform(multipart(CREATE_REVIEW_API_PATH, 1)
+        mockMvc.perform(multipart(PRODUCT_REVIEW_API_PATH, 1)
                 .param("content", "맛있어요")
                 .param("rating", String.valueOf(rating))
                 .contentType(MediaType.MULTIPART_FORM_DATA))
@@ -217,7 +277,7 @@ class ReviewControllerTest {
     @DisplayName("리뷰 내용이 없으면 HTTP 400을 응답한다.")
     void respond_400_when_review_content_is_empty() throws Exception {
 
-        mockMvc.perform(multipart(CREATE_REVIEW_API_PATH, 1)
+        mockMvc.perform(multipart(PRODUCT_REVIEW_API_PATH, 1)
                 .param("content", "")
                 .param("rating", "5")
                 .contentType(MediaType.MULTIPART_FORM_DATA))
@@ -231,7 +291,7 @@ class ReviewControllerTest {
     @DisplayName("리뷰 내용이 1000글자를 초과하면 HTTP 400을 응답한다.")
     void respond_400_when_review_content_exceed_1000_letters() throws Exception {
 
-        mockMvc.perform(multipart(CREATE_REVIEW_API_PATH, 1)
+        mockMvc.perform(multipart(PRODUCT_REVIEW_API_PATH, 1)
                 .param("content", "내용".repeat(501))
                 .param("rating", "5")
                 .contentType(MediaType.MULTIPART_FORM_DATA))
@@ -244,7 +304,7 @@ class ReviewControllerTest {
     @DisplayName("리뷰 내용이 1000글자이면 HTTP 201을 응답한다.")
     void respond_201_when_review_content_does_not_exceed_1000_letters() throws Exception {
 
-        mockMvc.perform(multipart(CREATE_REVIEW_API_PATH, 1)
+        mockMvc.perform(multipart(PRODUCT_REVIEW_API_PATH, 1)
                 .param("content", "내용".repeat(500))
                 .param("rating", "5")
                 .contentType(MediaType.MULTIPART_FORM_DATA))
@@ -258,13 +318,25 @@ class ReviewControllerTest {
 
         willThrow(IOException.class).given(reviewService).createReview(any(), anyLong(), any());
 
-        mockMvc.perform(multipart(CREATE_REVIEW_API_PATH, 1)
+        mockMvc.perform(multipart(PRODUCT_REVIEW_API_PATH, 1)
                 .param("content", "맛있어요")
                 .param("rating", "5")
                 .contentType(MediaType.MULTIPART_FORM_DATA))
             .andExpect(status().isInternalServerError())
             .andDo(print());
     }
+
+    User user = User.create("abc@naver.com", "password1!", "닉네임", List.of(Tag.builder().name("맵부심").build()));
+    Tag tag1 = Tag.builder().name("맵부심").build();
+    Tag tag2 = Tag.builder().name("초코러버").build();
+    Tag tag3 = Tag.builder().name("소식가").build();
+
+    UserTag userTag1 = UserTag.builder().user(user).tag(tag1).build();
+    UserTag userTag2 = UserTag.builder().user(user).tag(tag2).build();
+    UserTag userTag3 = UserTag.builder().user(user).tag(tag3).build();
+
+    ReviewImage reviewImage1 = ReviewImage.builder().imageUrl("리뷰 이미지 URL 1").build();
+    ReviewImage reviewImage2 = ReviewImage.builder().imageUrl("리뷰 이미지 URL 2").build();
 
     SearchReviewResponseDto responseDto1 = SearchReviewResponseDto.builder()
         .productId(13L)

--- a/src/test/java/com/cvsgo/repository/ReviewRepositoryTest.java
+++ b/src/test/java/com/cvsgo/repository/ReviewRepositoryTest.java
@@ -62,7 +62,7 @@ class ReviewRepositoryTest {
             .price(1800)
             .build();
         productRepository.save(product1);
-        review = Review.builder()
+        review1 = Review.builder()
             .user(user1)
             .product(product1)
             .content("맛있어요")
@@ -76,23 +76,23 @@ class ReviewRepositoryTest {
             .content("맛없어요")
             .imageUrls(List.of("https://blahblah/review/image1.png"))
             .build();
-        reviewRepository.saveAll(List.of(review, review2));
+        reviewRepository.saveAll(List.of(review1, review2));
     }
 
     @Test
     @DisplayName("리뷰 ID로 리뷰를 조회한다")
     void succeed_to_find_review_by_id() {
         reviewRepository.flush();
-        Review foundReview = reviewRepository.findById(review.getId()).orElseThrow();
-        assertThat(foundReview).isEqualTo(review);
+        Review foundReview = reviewRepository.findById(review1.getId()).orElseThrow();
+        assertThat(foundReview).isEqualTo(review1);
     }
 
     @Test
     @DisplayName("5점이었던 리뷰를 4점으로 수정한 후 해당 리뷰를 조회하면 4점이어야 한다")
     void succeed_to_update_review_rating() {
-        review.updateRating(4);
-        reviewRepository.saveAndFlush(review);
-        Review foundReview = reviewRepository.findById(review.getId()).orElseThrow();
+        review1.updateRating(4);
+        reviewRepository.saveAndFlush(review1);
+        Review foundReview = reviewRepository.findById(review1.getId()).orElseThrow();
         assertThat(foundReview.getRating()).isEqualTo(4);
     }
 
@@ -100,9 +100,9 @@ class ReviewRepositoryTest {
     @DisplayName("리뷰 내용을 수정한 후 해당 리뷰를 조회하면 수정 내용이 반영되어 있어야 한다")
     void succeed_to_update_review_content() {
         final String content = "진짜 맛있어요!!";
-        review.updateContent(content);
-        reviewRepository.saveAndFlush(review);
-        Review foundReview = reviewRepository.findById(review.getId()).orElseThrow();
+        review1.updateContent(content);
+        reviewRepository.saveAndFlush(review1);
+        Review foundReview = reviewRepository.findById(review1.getId()).orElseThrow();
         assertThat(foundReview.getContent()).isEqualTo(content);
     }
 
@@ -112,9 +112,9 @@ class ReviewRepositoryTest {
         List<String> imageUrls = new ArrayList<>();
         imageUrls.add("https://blahblah/review/불닭볶음면1.png");
         imageUrls.add("https://blahblah/review/불닭볶음면2.png");
-        review.updateReviewImages(imageUrls);
-        reviewRepository.saveAndFlush(review);
-        Review foundReview = reviewRepository.findById(review.getId()).orElseThrow();
+        review1.updateReviewImages(imageUrls);
+        reviewRepository.saveAndFlush(review1);
+        Review foundReview = reviewRepository.findById(review1.getId()).orElseThrow();
         assertThat(foundReview.getReviewImages().size()).isEqualTo(imageUrls.size());
     }
 
@@ -166,7 +166,7 @@ class ReviewRepositoryTest {
             .compareTo(reviews.get(reviews.size() - 1).getCreatedAt())).isGreaterThanOrEqualTo(0);
     }
 
-    private Review review;
+    private Review review1;
     private Review review2;
 
     private Product product1;

--- a/src/test/java/com/cvsgo/repository/ReviewRepositoryTest.java
+++ b/src/test/java/com/cvsgo/repository/ReviewRepositoryTest.java
@@ -166,6 +166,15 @@ class ReviewRepositoryTest {
             .compareTo(reviews.get(reviews.size() - 1).getCreatedAt())).isGreaterThanOrEqualTo(0);
     }
 
+    @Test
+    @DisplayName("필터를 적용한 특정 상품의 리뷰 개수를 조회한다")
+    void succeed_to_get_total_count() {
+        ReadReviewRequestDto requestDto = new ReadReviewRequestDto(List.of(), List.of(), null);
+        Long totalCount = reviewRepository.countByProductIdAndFilter(product1.getId(), requestDto);
+
+        assertThat(totalCount).isEqualTo(2L);
+    }
+
     private Review review1;
     private Review review2;
 

--- a/src/test/java/com/cvsgo/repository/ReviewRepositoryTest.java
+++ b/src/test/java/com/cvsgo/repository/ReviewRepositoryTest.java
@@ -122,8 +122,8 @@ class ReviewRepositoryTest {
     @DisplayName("필터를 적용하지 않고 특정 상품의 리뷰를 조회하면 특정 상품의 모든 리뷰가 검색된다")
     void should_return_all_reviews_of_the_product() {
         ReadReviewRequestDto requestDto = new ReadReviewRequestDto(List.of(), List.of(), null);
-        List<ReadReviewQueryDto> reviews = reviewRepository.findAllByFilter(user1, product1.getId(),
-            requestDto, PageRequest.of(0, 20));
+        List<ReadReviewQueryDto> reviews = reviewRepository.findAllByProductIdAndFilter(user1,
+            product1.getId(), requestDto, PageRequest.of(0, 20));
 
         assertThat(reviews.size()).isEqualTo(2);
     }
@@ -133,8 +133,8 @@ class ReviewRepositoryTest {
     void success_to_read_product_reviews() {
         ReadReviewRequestDto requestDto = new ReadReviewRequestDto(
             List.of(tag1.getId(), tag2.getId(), tag3.getId()), List.of(5), null);
-        List<ReadReviewQueryDto> reviews = reviewRepository.findAllByFilter(user1, product1.getId(),
-            requestDto, PageRequest.of(0, 20));
+        List<ReadReviewQueryDto> reviews = reviewRepository.findAllByProductIdAndFilter(user1,
+            product1.getId(), requestDto, PageRequest.of(0, 20));
 
         assertThat(reviews.size()).isEqualTo(1);
         assertThat(reviews.get(0).getRating()).isEqualTo(5);
@@ -146,8 +146,8 @@ class ReviewRepositoryTest {
         ReadReviewRequestDto requestDto = new ReadReviewRequestDto(
             List.of(tag1.getId(), tag2.getId(), tag3.getId()), List.of(5), ReviewSortBy.RATING);
 
-        List<ReadReviewQueryDto> reviews = reviewRepository.findAllByFilter(user1, product1.getId(),
-            requestDto, PageRequest.of(0, 20));
+        List<ReadReviewQueryDto> reviews = reviewRepository.findAllByProductIdAndFilter(user1,
+            product1.getId(), requestDto, PageRequest.of(0, 20));
 
         assertThat(reviews.get(0).getRating()).isGreaterThanOrEqualTo(
             reviews.get(reviews.size() - 1).getRating());
@@ -159,8 +159,8 @@ class ReviewRepositoryTest {
         ReadReviewRequestDto requestDto = new ReadReviewRequestDto(
             List.of(tag1.getId(), tag2.getId(), tag3.getId()), List.of(5), ReviewSortBy.LATEST);
 
-        List<ReadReviewQueryDto> reviews = reviewRepository.findAllByFilter(user1, product1.getId(),
-            requestDto, PageRequest.of(0, 20));
+        List<ReadReviewQueryDto> reviews = reviewRepository.findAllByProductIdAndFilter(user1,
+            product1.getId(), requestDto, PageRequest.of(0, 20));
 
         assertThat(reviews.get(0).getCreatedAt()
             .compareTo(reviews.get(reviews.size() - 1).getCreatedAt())).isGreaterThanOrEqualTo(0);

--- a/src/test/java/com/cvsgo/repository/ReviewRepositoryTest.java
+++ b/src/test/java/com/cvsgo/repository/ReviewRepositoryTest.java
@@ -3,8 +3,12 @@ package com.cvsgo.repository;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.cvsgo.config.TestConfig;
+import com.cvsgo.dto.review.ReadReviewQueryDto;
+import com.cvsgo.dto.review.ReadReviewRequestDto;
+import com.cvsgo.dto.review.ReviewSortBy;
 import com.cvsgo.entity.Product;
 import com.cvsgo.entity.Review;
+import com.cvsgo.entity.Tag;
 import com.cvsgo.entity.User;
 import java.util.ArrayList;
 import java.util.List;
@@ -15,14 +19,20 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @Import(TestConfig.class)
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@EnableJpaAuditing
 class ReviewRepositoryTest {
 
     @Autowired
     UserRepository userRepository;
+
+    @Autowired
+    TagRepository tagRepository;
 
     @Autowired
     ProductRepository productRepository;
@@ -33,15 +43,21 @@ class ReviewRepositoryTest {
     @Autowired
     ReviewImageRepository reviewImageRepository;
 
-    Review review;
-
     @BeforeEach
     void initData() {
-        User user1 = User.create("abc@naver.com", "password1!", "닉네임", new ArrayList<>());
-        User user2 = User.create("abcd@naver.com", "password1!", "닉네임2", new ArrayList<>());
+        tag1 = Tag.builder().name("맵찔이").group(1).build();
+        tag2 = Tag.builder().name("맵부심").group(1).build();
+        tag3 = Tag.builder().name("초코러버").group(2).build();
+        tag4 = Tag.builder().name("비건").group(3).build();
+        tag5 = Tag.builder().name("다이어터").group(4).build();
+        tag6 = Tag.builder().name("대식가").group(5).build();
+        tag7 = Tag.builder().name("소식가").group(5).build();
+        tagRepository.saveAll(List.of(tag1, tag2, tag3, tag4, tag5, tag6, tag7));
+        user1 = User.create("abc@naver.com", "password1!", "닉네임", List.of(tag2, tag3, tag7));
+        user2 = User.create("abcd@naver.com", "password1!", "닉네임2", new ArrayList<>());
         userRepository.save(user1);
         userRepository.save(user2);
-        Product product1 = Product.builder()
+        product1 = Product.builder()
             .name("불닭볶음면")
             .price(1800)
             .build();
@@ -53,7 +69,14 @@ class ReviewRepositoryTest {
             .rating(5)
             .imageUrls(new ArrayList<>())
             .build();
-        reviewRepository.save(review);
+        review2 = Review.builder()
+            .user(user2)
+            .product(product1)
+            .rating(2)
+            .content("맛없어요")
+            .imageUrls(List.of("https://blahblah/review/image1.png"))
+            .build();
+        reviewRepository.saveAll(List.of(review, review2));
     }
 
     @Test
@@ -94,5 +117,69 @@ class ReviewRepositoryTest {
         Review foundReview = reviewRepository.findById(review.getId()).orElseThrow();
         assertThat(foundReview.getReviewImages().size()).isEqualTo(imageUrls.size());
     }
+
+    @Test
+    @DisplayName("필터를 적용하지 않고 특정 상품의 리뷰를 조회하면 특정 상품의 모든 리뷰가 검색된다")
+    void should_return_all_reviews_of_the_product() {
+        ReadReviewRequestDto requestDto = new ReadReviewRequestDto(List.of(), List.of(), null);
+        List<ReadReviewQueryDto> reviews = reviewRepository.findAllByFilter(user1, product1.getId(),
+            requestDto, PageRequest.of(0, 20));
+
+        assertThat(reviews.size()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("별점 5점 필터를 적용하여 특정 상품의 리뷰를 조회하면 5점인 리뷰들만 조회된다")
+    void success_to_read_product_reviews() {
+        ReadReviewRequestDto requestDto = new ReadReviewRequestDto(
+            List.of(tag1.getId(), tag2.getId(), tag3.getId()), List.of(5), null);
+        List<ReadReviewQueryDto> reviews = reviewRepository.findAllByFilter(user1, product1.getId(),
+            requestDto, PageRequest.of(0, 20));
+
+        assertThat(reviews.size()).isEqualTo(1);
+        assertThat(reviews.get(0).getRating()).isEqualTo(5);
+    }
+
+    @Test
+    @DisplayName("별점 내림차순으로 정렬하여 특정 상품의 리뷰를 조회하면 첫번째 리뷰 별점이 마지막 리뷰 별점보다 크거나 같아야 한다")
+    void rating_of_first_review_should_greater_than_or_equal_to_rating_of_last_when_sorted_by_rating_descending_order() {
+        ReadReviewRequestDto requestDto = new ReadReviewRequestDto(
+            List.of(tag1.getId(), tag2.getId(), tag3.getId()), List.of(5), ReviewSortBy.RATING);
+
+        List<ReadReviewQueryDto> reviews = reviewRepository.findAllByFilter(user1, product1.getId(),
+            requestDto, PageRequest.of(0, 20));
+
+        assertThat(reviews.get(0).getRating()).isGreaterThanOrEqualTo(
+            reviews.get(reviews.size() - 1).getRating());
+    }
+
+    @Test
+    @DisplayName("최신순으로 정렬하여 특정 상품의 리뷰를 조회하면 첫번째 리뷰의 생성시각이 마지막 리뷰의 생성 시각보다 크거나 같아야 한다")
+    void created_time_of_first_review_should_greater_than_or_equal_to_created_time_of_last_review_when_sorted_by_review_createdAt_descending_order() {
+        ReadReviewRequestDto requestDto = new ReadReviewRequestDto(
+            List.of(tag1.getId(), tag2.getId(), tag3.getId()), List.of(5), ReviewSortBy.LATEST);
+
+        List<ReadReviewQueryDto> reviews = reviewRepository.findAllByFilter(user1, product1.getId(),
+            requestDto, PageRequest.of(0, 20));
+
+        assertThat(reviews.get(0).getCreatedAt()
+            .compareTo(reviews.get(reviews.size() - 1).getCreatedAt())).isGreaterThanOrEqualTo(0);
+    }
+
+    private Review review;
+    private Review review2;
+
+    private Product product1;
+
+    private User user1;
+    private User user2;
+
+    private Tag tag1;
+    private Tag tag2;
+    private Tag tag3;
+    private Tag tag4;
+    private Tag tag5;
+    private Tag tag6;
+    private Tag tag7;
 
 }

--- a/src/test/java/com/cvsgo/service/ReviewServiceTest.java
+++ b/src/test/java/com/cvsgo/service/ReviewServiceTest.java
@@ -101,7 +101,7 @@ class ReviewServiceTest {
     @Test
     @DisplayName("특정 상품의 리뷰를 정상적으로 조회한다")
     void succeed_to_read_product_review() {
-        ReadReviewQueryDto queryDto1 = new ReadReviewQueryDto(user1, userFollow, review);
+        ReadReviewQueryDto queryDto1 = new ReadReviewQueryDto(user1, userFollow, null, review);
         ReadReviewRequestDto requestDto = new ReadReviewRequestDto(List.of(1L, 2L, 3L),
             List.of(4, 5), ReviewSortBy.LATEST);
 
@@ -124,12 +124,12 @@ class ReviewServiceTest {
     @Test
     @DisplayName("준회원인 사용자가 특정 상품의 리뷰 0페이지를 조회하면 5개만 조회된다")
     void should_throw_ForbiddenUserException_when_associate_user_read_first_page_of_product_reviews() {
-        ReadReviewQueryDto queryDto1 = new ReadReviewQueryDto(user1, userFollow, review);
-        ReadReviewQueryDto queryDto2 = new ReadReviewQueryDto(user1, userFollow, review);
-        ReadReviewQueryDto queryDto3 = new ReadReviewQueryDto(user1, userFollow, review);
-        ReadReviewQueryDto queryDto4 = new ReadReviewQueryDto(user1, userFollow, review);
-        ReadReviewQueryDto queryDto5 = new ReadReviewQueryDto(user1, userFollow, review);
-        ReadReviewQueryDto queryDto6 = new ReadReviewQueryDto(user1, userFollow, review);
+        ReadReviewQueryDto queryDto1 = new ReadReviewQueryDto(user1, userFollow, null, review);
+        ReadReviewQueryDto queryDto2 = new ReadReviewQueryDto(user1, userFollow, null, review);
+        ReadReviewQueryDto queryDto3 = new ReadReviewQueryDto(user1, userFollow, null, review);
+        ReadReviewQueryDto queryDto4 = new ReadReviewQueryDto(user1, userFollow, null, review);
+        ReadReviewQueryDto queryDto5 = new ReadReviewQueryDto(user1, userFollow, null, review);
+        ReadReviewQueryDto queryDto6 = new ReadReviewQueryDto(user1, userFollow, null, review);
         ReadReviewRequestDto requestDto = new ReadReviewRequestDto(List.of(1L, 2L, 3L),
             List.of(4, 5), ReviewSortBy.LATEST);
 
@@ -159,12 +159,12 @@ class ReviewServiceTest {
     @Test
     @DisplayName("정회원인 사용자가 특정 상품의 리뷰 0페이지를 조회하면 정상적으로 조회된다")
     void should_throw_ForbiddenUserException_when_regular_user_read_first_page_of_product_reviews() {
-        ReadReviewQueryDto queryDto1 = new ReadReviewQueryDto(user2, userFollow, review);
-        ReadReviewQueryDto queryDto2 = new ReadReviewQueryDto(user2, userFollow, review);
-        ReadReviewQueryDto queryDto3 = new ReadReviewQueryDto(user2, userFollow, review);
-        ReadReviewQueryDto queryDto4 = new ReadReviewQueryDto(user2, userFollow, review);
-        ReadReviewQueryDto queryDto5 = new ReadReviewQueryDto(user2, userFollow, review);
-        ReadReviewQueryDto queryDto6 = new ReadReviewQueryDto(user2, userFollow, review);
+        ReadReviewQueryDto queryDto1 = new ReadReviewQueryDto(user2, userFollow, null, review);
+        ReadReviewQueryDto queryDto2 = new ReadReviewQueryDto(user2, userFollow, null, review);
+        ReadReviewQueryDto queryDto3 = new ReadReviewQueryDto(user2, userFollow, null, review);
+        ReadReviewQueryDto queryDto4 = new ReadReviewQueryDto(user2, userFollow, null, review);
+        ReadReviewQueryDto queryDto5 = new ReadReviewQueryDto(user2, userFollow, null, review);
+        ReadReviewQueryDto queryDto6 = new ReadReviewQueryDto(user2, userFollow, null, review);
         ReadReviewRequestDto requestDto = new ReadReviewRequestDto(List.of(1L, 2L, 3L),
             List.of(4, 5), ReviewSortBy.LATEST);
 

--- a/src/test/java/com/cvsgo/service/ReviewServiceTest.java
+++ b/src/test/java/com/cvsgo/service/ReviewServiceTest.java
@@ -1,16 +1,21 @@
 package com.cvsgo.service;
 
 import com.cvsgo.dto.review.CreateReviewRequestDto;
+import com.cvsgo.dto.review.ReadReviewQueryDto;
+import com.cvsgo.dto.review.ReadReviewRequestDto;
+import com.cvsgo.dto.review.ReadReviewResponseDto;
+import com.cvsgo.dto.review.ReviewSortBy;
 import com.cvsgo.dto.review.SearchReviewQueryDto;
 import com.cvsgo.dto.review.SearchReviewRequestDto;
 import com.cvsgo.dto.review.UpdateReviewRequestDto;
 import com.cvsgo.entity.Product;
 import com.cvsgo.entity.Review;
 import com.cvsgo.entity.ReviewImage;
+import com.cvsgo.entity.Role;
 import com.cvsgo.entity.Tag;
 import com.cvsgo.entity.User;
+import com.cvsgo.entity.UserFollow;
 import com.cvsgo.entity.UserTag;
-import com.cvsgo.exception.auth.UnauthorizedUserException;
 import com.cvsgo.exception.product.NotFoundProductException;
 import com.cvsgo.exception.review.NotFoundReviewException;
 import com.cvsgo.exception.user.ForbiddenUserException;
@@ -26,12 +31,15 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
 
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -91,6 +99,119 @@ class ReviewServiceTest {
     }
 
     @Test
+    @DisplayName("특정 상품의 리뷰를 정상적으로 조회한다")
+    void succeed_to_read_product_review() {
+        ReadReviewQueryDto queryDto1 = new ReadReviewQueryDto(user1, userFollow, review);
+        ReadReviewRequestDto requestDto = new ReadReviewRequestDto(List.of(1L, 2L, 3L),
+            List.of(4, 5), ReviewSortBy.LATEST);
+
+        given(reviewRepository.findAllByFilter(any(), anyLong(), any(), any()))
+            .willReturn(List.of(queryDto1));
+        given(userTagRepository.findByUserIdIn(anyList()))
+            .willReturn(List.of(userTag));
+        given(reviewImageRepository.findByReviewIdIn(anyList()))
+            .willReturn(List.of(reviewImage));
+
+        List<ReadReviewResponseDto> reviews = reviewService.getProductReviewList(user2, 1L,
+            requestDto, PageRequest.of(0, 20));
+
+        assertThat(reviews.size()).isEqualTo(1);
+        then(reviewRepository).should(times(1)).findAllByFilter(any(), anyLong(), any(), any());
+        then(userTagRepository).should(times(1)).findByUserIdIn(any());
+        then(reviewImageRepository).should(times(1)).findByReviewIdIn(any());
+    }
+
+    @Test
+    @DisplayName("준회원인 사용자가 특정 상품의 리뷰 0페이지를 조회하면 5개만 조회된다")
+    void should_throw_ForbiddenUserException_when_associate_user_read_first_page_of_product_reviews() {
+        ReadReviewQueryDto queryDto1 = new ReadReviewQueryDto(user1, userFollow, review);
+        ReadReviewQueryDto queryDto2 = new ReadReviewQueryDto(user1, userFollow, review);
+        ReadReviewQueryDto queryDto3 = new ReadReviewQueryDto(user1, userFollow, review);
+        ReadReviewQueryDto queryDto4 = new ReadReviewQueryDto(user1, userFollow, review);
+        ReadReviewQueryDto queryDto5 = new ReadReviewQueryDto(user1, userFollow, review);
+        ReadReviewQueryDto queryDto6 = new ReadReviewQueryDto(user1, userFollow, review);
+        ReadReviewRequestDto requestDto = new ReadReviewRequestDto(List.of(1L, 2L, 3L),
+            List.of(4, 5), ReviewSortBy.LATEST);
+
+        PageRequest size20 = PageRequest.of(0, 20);
+        PageRequest size5 = PageRequest.of(0, 5);
+
+        lenient().when(reviewRepository.findAllByFilter(any(), anyLong(), any(), eq(size20)))
+            .thenReturn(List.of(queryDto1, queryDto2, queryDto3, queryDto4, queryDto5,
+                queryDto6)); // page size가 20인 경우 6개
+        lenient().when(reviewRepository.findAllByFilter(any(), anyLong(), any(), eq(size5)))
+            .thenReturn(List.of(queryDto1, queryDto2, queryDto3, queryDto4,
+                queryDto5)); // page size가 5인 경우 5개
+        given(userTagRepository.findByUserIdIn(anyList()))
+            .willReturn(List.of(userTag));
+        given(reviewImageRepository.findByReviewIdIn(anyList()))
+            .willReturn(List.of(reviewImage));
+
+        List<ReadReviewResponseDto> reviews = reviewService.getProductReviewList(user1, 1L,
+            requestDto, PageRequest.of(0, 20));
+
+        assertThat(reviews.size()).isLessThanOrEqualTo(5); // user1은 준회원이기 때문에 최대 5개까지만 조회됨
+        then(reviewRepository).should(times(1)).findAllByFilter(any(), anyLong(), any(), any());
+        then(userTagRepository).should(times(1)).findByUserIdIn(any());
+        then(reviewImageRepository).should(times(1)).findByReviewIdIn(any());
+    }
+
+    @Test
+    @DisplayName("정회원인 사용자가 특정 상품의 리뷰 0페이지를 조회하면 정상적으로 조회된다")
+    void should_throw_ForbiddenUserException_when_regular_user_read_first_page_of_product_reviews() {
+        ReadReviewQueryDto queryDto1 = new ReadReviewQueryDto(user2, userFollow, review);
+        ReadReviewQueryDto queryDto2 = new ReadReviewQueryDto(user2, userFollow, review);
+        ReadReviewQueryDto queryDto3 = new ReadReviewQueryDto(user2, userFollow, review);
+        ReadReviewQueryDto queryDto4 = new ReadReviewQueryDto(user2, userFollow, review);
+        ReadReviewQueryDto queryDto5 = new ReadReviewQueryDto(user2, userFollow, review);
+        ReadReviewQueryDto queryDto6 = new ReadReviewQueryDto(user2, userFollow, review);
+        ReadReviewRequestDto requestDto = new ReadReviewRequestDto(List.of(1L, 2L, 3L),
+            List.of(4, 5), ReviewSortBy.LATEST);
+
+        PageRequest size20 = PageRequest.of(0, 20);
+        PageRequest size5 = PageRequest.of(0, 5);
+
+        lenient().when(reviewRepository.findAllByFilter(any(), anyLong(), any(), eq(size20)))
+            .thenReturn(List.of(queryDto1, queryDto2, queryDto3, queryDto4, queryDto5,
+                queryDto6)); // page size가 20인 경우 6개
+        lenient().when(reviewRepository.findAllByFilter(any(), anyLong(), any(), eq(size5)))
+            .thenReturn(List.of(queryDto1, queryDto2, queryDto3, queryDto4,
+                queryDto5)); // page size가 5인 경우 5개
+        given(userTagRepository.findByUserIdIn(anyList()))
+            .willReturn(List.of(userTag));
+        given(reviewImageRepository.findByReviewIdIn(anyList()))
+            .willReturn(List.of(reviewImage));
+
+        List<ReadReviewResponseDto> reviews = reviewService.getProductReviewList(user2, 1L,
+            requestDto, PageRequest.of(0, 20));
+
+        assertThat(reviews.size()).isEqualTo(6); // user2는 정회원이므로 6개가 조회됨
+        then(reviewRepository).should(times(1)).findAllByFilter(any(), anyLong(), any(), any());
+        then(userTagRepository).should(times(1)).findByUserIdIn(any());
+        then(reviewImageRepository).should(times(1)).findByReviewIdIn(any());
+    }
+
+    @Test
+    @DisplayName("준회원인 사용자가 특정 상품의 리뷰 1페이지를 조회하면 ForbiddenUserException이 발생한다")
+    void should_throw_ForbiddenUserException_when_associate_user_read_second_page_of_product_reviews() {
+        ReadReviewRequestDto requestDto = new ReadReviewRequestDto(List.of(1L, 2L, 3L),
+            List.of(4, 5), ReviewSortBy.LATEST);
+
+        assertThrows(ForbiddenUserException.class,
+            () -> reviewService.getProductReviewList(user1, 1L, requestDto, PageRequest.of(1, 20)));
+    }
+
+    @Test
+    @DisplayName("로그인하지 않은 사용자가 특정 상품의 리뷰 1페이지를 조회하면 ForbiddenUserException이 발생한다")
+    void should_throw_ForbiddenUserException_when_non_login_user_read_second_page_of_product_reviews() {
+        ReadReviewRequestDto requestDto = new ReadReviewRequestDto(List.of(1L, 2L, 3L),
+            List.of(4, 5), null);
+
+        assertThrows(ForbiddenUserException.class,
+            () -> reviewService.getProductReviewList(null, 1L, requestDto, PageRequest.of(1, 20)));
+    }
+
+    @Test
     @DisplayName("해당 ID의 상품이 없는 경우 NotFoundProductException이 발생한다")
     void should_throw_NotFoundProductException_when_product_does_not_exist() {
         given(productRepository.findById(anyLong()))
@@ -120,13 +241,28 @@ class ReviewServiceTest {
             () -> reviewService.updateReview(user1, 100L, updateReviewRequestDto));
     }
 
-    User user1 = User.builder().build();
+    User user1 = User.builder()
+        .id(1L)
+        .userId("abc@naver.com")
+        .nickname("사용자1")
+        .role(Role.ASSOCIATE)
+        .build();
 
-    User user2 = User.builder().id(2L).build();
+    User user2 = User.builder()
+        .id(2L)
+        .userId("abcd@naver.com")
+        .nickname("사용자2")
+        .role(Role.REGULAR)
+        .build();
 
     Product product = Product.builder().build();
 
-    Review review = Review.builder().user(user2).imageUrls(new ArrayList<>()).build();
+    Review review = Review.builder()
+        .id(1L)
+        .user(user2)
+        .rating(5)
+        .imageUrls(List.of())
+        .build();
 
     CreateReviewRequestDto createReviewRequestDto = CreateReviewRequestDto.builder().build();
 
@@ -158,6 +294,11 @@ class ReviewServiceTest {
     ReviewImage reviewImage = ReviewImage.builder()
         .review(Review.builder().id(1L).imageUrls(new ArrayList<>()).build())
         .imageUrl("https://어쩌구저쩌구/review/리뷰이미지.png")
+        .build();
+
+    UserFollow userFollow = UserFollow.builder()
+        .following(user1)
+        .follower(user2)
         .build();
 
 }

--- a/src/test/java/com/cvsgo/service/ReviewServiceTest.java
+++ b/src/test/java/com/cvsgo/service/ReviewServiceTest.java
@@ -107,23 +107,26 @@ class ReviewServiceTest {
 
         given(reviewRepository.findAllByFilter(any(), anyLong(), any(), any()))
             .willReturn(List.of(queryDto1));
+        given(reviewRepository.countByProductIdAndFilter(anyLong(), any()))
+            .willReturn(1L);
         given(userTagRepository.findByUserIdIn(anyList()))
             .willReturn(List.of(userTag));
         given(reviewImageRepository.findByReviewIdIn(anyList()))
             .willReturn(List.of(reviewImage));
 
         List<ReadReviewResponseDto> reviews = reviewService.getProductReviewList(user2, 1L,
-            requestDto, PageRequest.of(0, 20));
+            requestDto, PageRequest.of(0, 20)).getContent();
 
         assertThat(reviews.size()).isEqualTo(1);
         then(reviewRepository).should(times(1)).findAllByFilter(any(), anyLong(), any(), any());
+        then(reviewRepository).should(times(1)).countByProductIdAndFilter(anyLong(), any());
         then(userTagRepository).should(times(1)).findByUserIdIn(any());
         then(reviewImageRepository).should(times(1)).findByReviewIdIn(any());
     }
 
     @Test
     @DisplayName("준회원인 사용자가 특정 상품의 리뷰 0페이지를 조회하면 5개만 조회된다")
-    void should_throw_ForbiddenUserException_when_associate_user_read_first_page_of_product_reviews() {
+    void should_get_only_five_reviews_when_associate_user_read_first_page_of_product_reviews() {
         ReadReviewQueryDto queryDto1 = new ReadReviewQueryDto(user1, userFollow, null, review);
         ReadReviewQueryDto queryDto2 = new ReadReviewQueryDto(user1, userFollow, null, review);
         ReadReviewQueryDto queryDto3 = new ReadReviewQueryDto(user1, userFollow, null, review);
@@ -139,16 +142,18 @@ class ReviewServiceTest {
         lenient().when(reviewRepository.findAllByFilter(any(), anyLong(), any(), eq(size20)))
             .thenReturn(List.of(queryDto1, queryDto2, queryDto3, queryDto4, queryDto5,
                 queryDto6)); // page size가 20인 경우 6개
+        lenient().when(reviewRepository.countByProductIdAndFilter(anyLong(), any())).thenReturn(6L);
         lenient().when(reviewRepository.findAllByFilter(any(), anyLong(), any(), eq(size5)))
             .thenReturn(List.of(queryDto1, queryDto2, queryDto3, queryDto4,
                 queryDto5)); // page size가 5인 경우 5개
+        lenient().when(reviewRepository.countByProductIdAndFilter(anyLong(), any())).thenReturn(5L);
         given(userTagRepository.findByUserIdIn(anyList()))
             .willReturn(List.of(userTag));
         given(reviewImageRepository.findByReviewIdIn(anyList()))
             .willReturn(List.of(reviewImage));
 
         List<ReadReviewResponseDto> reviews = reviewService.getProductReviewList(user1, 1L,
-            requestDto, PageRequest.of(0, 20));
+            requestDto, PageRequest.of(0, 20)).getContent();
 
         assertThat(reviews.size()).isLessThanOrEqualTo(5); // user1은 준회원이기 때문에 최대 5개까지만 조회됨
         then(reviewRepository).should(times(1)).findAllByFilter(any(), anyLong(), any(), any());
@@ -174,16 +179,18 @@ class ReviewServiceTest {
         lenient().when(reviewRepository.findAllByFilter(any(), anyLong(), any(), eq(size20)))
             .thenReturn(List.of(queryDto1, queryDto2, queryDto3, queryDto4, queryDto5,
                 queryDto6)); // page size가 20인 경우 6개
+        lenient().when(reviewRepository.countByProductIdAndFilter(anyLong(), any())).thenReturn(6L);
         lenient().when(reviewRepository.findAllByFilter(any(), anyLong(), any(), eq(size5)))
             .thenReturn(List.of(queryDto1, queryDto2, queryDto3, queryDto4,
                 queryDto5)); // page size가 5인 경우 5개
+        lenient().when(reviewRepository.countByProductIdAndFilter(anyLong(), any())).thenReturn(5L);
         given(userTagRepository.findByUserIdIn(anyList()))
             .willReturn(List.of(userTag));
         given(reviewImageRepository.findByReviewIdIn(anyList()))
             .willReturn(List.of(reviewImage));
 
         List<ReadReviewResponseDto> reviews = reviewService.getProductReviewList(user2, 1L,
-            requestDto, PageRequest.of(0, 20));
+            requestDto, PageRequest.of(0, 20)).getContent();
 
         assertThat(reviews.size()).isEqualTo(6); // user2는 정회원이므로 6개가 조회됨
         then(reviewRepository).should(times(1)).findAllByFilter(any(), anyLong(), any(), any());

--- a/src/test/java/com/cvsgo/service/ReviewServiceTest.java
+++ b/src/test/java/com/cvsgo/service/ReviewServiceTest.java
@@ -23,6 +23,7 @@ import com.cvsgo.repository.ProductRepository;
 import com.cvsgo.repository.ReviewImageRepository;
 import com.cvsgo.repository.ReviewRepository;
 import com.cvsgo.repository.UserTagRepository;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -101,7 +102,9 @@ class ReviewServiceTest {
     @Test
     @DisplayName("특정 상품의 리뷰를 정상적으로 조회한다")
     void succeed_to_read_product_review() {
-        ReadReviewQueryDto queryDto1 = new ReadReviewQueryDto(user1, userFollow, null, review);
+        ReadReviewQueryDto queryDto1 = new ReadReviewQueryDto(user1.getId(), review.getId(),
+            user1.getNickname(), user1.getProfileImageUrl(), userFollow, review.getContent(),
+            review.getRating(), null, review.getLikeCount(), LocalDateTime.now());
         ReadReviewRequestDto requestDto = new ReadReviewRequestDto(List.of(1L, 2L, 3L),
             List.of(4, 5), ReviewSortBy.LATEST);
 
@@ -128,12 +131,24 @@ class ReviewServiceTest {
     @Test
     @DisplayName("준회원인 사용자가 특정 상품의 리뷰 0페이지를 조회하면 5개만 조회된다")
     void should_get_only_five_reviews_when_associate_user_read_first_page_of_product_reviews() {
-        ReadReviewQueryDto queryDto1 = new ReadReviewQueryDto(user1, userFollow, null, review);
-        ReadReviewQueryDto queryDto2 = new ReadReviewQueryDto(user1, userFollow, null, review);
-        ReadReviewQueryDto queryDto3 = new ReadReviewQueryDto(user1, userFollow, null, review);
-        ReadReviewQueryDto queryDto4 = new ReadReviewQueryDto(user1, userFollow, null, review);
-        ReadReviewQueryDto queryDto5 = new ReadReviewQueryDto(user1, userFollow, null, review);
-        ReadReviewQueryDto queryDto6 = new ReadReviewQueryDto(user1, userFollow, null, review);
+        ReadReviewQueryDto queryDto1 = new ReadReviewQueryDto(user1.getId(), review.getId(),
+            user1.getNickname(), user1.getProfileImageUrl(), userFollow, review.getContent(),
+            review.getRating(), null, review.getLikeCount(), LocalDateTime.now());
+        ReadReviewQueryDto queryDto2 = new ReadReviewQueryDto(user1.getId(), review.getId(),
+            user1.getNickname(), user1.getProfileImageUrl(), userFollow, review.getContent(),
+            review.getRating(), null, review.getLikeCount(), LocalDateTime.now());
+        ReadReviewQueryDto queryDto3 = new ReadReviewQueryDto(user1.getId(), review.getId(),
+            user1.getNickname(), user1.getProfileImageUrl(), userFollow, review.getContent(),
+            review.getRating(), null, review.getLikeCount(), LocalDateTime.now());
+        ReadReviewQueryDto queryDto4 = new ReadReviewQueryDto(user1.getId(), review.getId(),
+            user1.getNickname(), user1.getProfileImageUrl(), userFollow, review.getContent(),
+            review.getRating(), null, review.getLikeCount(), LocalDateTime.now());
+        ReadReviewQueryDto queryDto5 = new ReadReviewQueryDto(user1.getId(), review.getId(),
+            user1.getNickname(), user1.getProfileImageUrl(), userFollow, review.getContent(),
+            review.getRating(), null, review.getLikeCount(), LocalDateTime.now());
+        ReadReviewQueryDto queryDto6 = new ReadReviewQueryDto(user1.getId(), review.getId(),
+            user1.getNickname(), user1.getProfileImageUrl(), userFollow, review.getContent(),
+            review.getRating(), null, review.getLikeCount(), LocalDateTime.now());
         ReadReviewRequestDto requestDto = new ReadReviewRequestDto(List.of(1L, 2L, 3L),
             List.of(4, 5), ReviewSortBy.LATEST);
 
@@ -168,12 +183,24 @@ class ReviewServiceTest {
     @Test
     @DisplayName("정회원인 사용자가 특정 상품의 리뷰 0페이지를 조회하면 정상적으로 조회된다")
     void should_throw_ForbiddenUserException_when_regular_user_read_first_page_of_product_reviews() {
-        ReadReviewQueryDto queryDto1 = new ReadReviewQueryDto(user2, userFollow, null, review);
-        ReadReviewQueryDto queryDto2 = new ReadReviewQueryDto(user2, userFollow, null, review);
-        ReadReviewQueryDto queryDto3 = new ReadReviewQueryDto(user2, userFollow, null, review);
-        ReadReviewQueryDto queryDto4 = new ReadReviewQueryDto(user2, userFollow, null, review);
-        ReadReviewQueryDto queryDto5 = new ReadReviewQueryDto(user2, userFollow, null, review);
-        ReadReviewQueryDto queryDto6 = new ReadReviewQueryDto(user2, userFollow, null, review);
+        ReadReviewQueryDto queryDto1 = new ReadReviewQueryDto(user2.getId(), review.getId(),
+            user2.getNickname(), user2.getProfileImageUrl(), userFollow, review.getContent(),
+            review.getRating(), null, review.getLikeCount(), LocalDateTime.now());
+        ReadReviewQueryDto queryDto2 = new ReadReviewQueryDto(user2.getId(), review.getId(),
+            user2.getNickname(), user2.getProfileImageUrl(), userFollow, review.getContent(),
+            review.getRating(), null, review.getLikeCount(), LocalDateTime.now());
+        ReadReviewQueryDto queryDto3 = new ReadReviewQueryDto(user2.getId(), review.getId(),
+            user2.getNickname(), user2.getProfileImageUrl(), userFollow, review.getContent(),
+            review.getRating(), null, review.getLikeCount(), LocalDateTime.now());
+        ReadReviewQueryDto queryDto4 = new ReadReviewQueryDto(user2.getId(), review.getId(),
+            user2.getNickname(), user2.getProfileImageUrl(), userFollow, review.getContent(),
+            review.getRating(), null, review.getLikeCount(), LocalDateTime.now());
+        ReadReviewQueryDto queryDto5 = new ReadReviewQueryDto(user2.getId(), review.getId(),
+            user2.getNickname(), user2.getProfileImageUrl(), userFollow, review.getContent(),
+            review.getRating(), null, review.getLikeCount(), LocalDateTime.now());
+        ReadReviewQueryDto queryDto6 = new ReadReviewQueryDto(user2.getId(), review.getId(),
+            user2.getNickname(), user2.getProfileImageUrl(), userFollow, review.getContent(),
+            review.getRating(), null, review.getLikeCount(), LocalDateTime.now());
         ReadReviewRequestDto requestDto = new ReadReviewRequestDto(List.of(1L, 2L, 3L),
             List.of(4, 5), ReviewSortBy.LATEST);
 

--- a/src/test/java/com/cvsgo/service/ReviewServiceTest.java
+++ b/src/test/java/com/cvsgo/service/ReviewServiceTest.java
@@ -114,7 +114,7 @@ class ReviewServiceTest {
         given(reviewImageRepository.findByReviewIdIn(anyList()))
             .willReturn(List.of(reviewImage));
 
-        List<ReadReviewResponseDto> reviews = reviewService.getProductReviewList(user2, 1L,
+        List<ReadReviewResponseDto> reviews = reviewService.readProductReviewList(user2, 1L,
             requestDto, PageRequest.of(0, 20)).getContent();
 
         assertThat(reviews.size()).isEqualTo(1);
@@ -155,7 +155,7 @@ class ReviewServiceTest {
         given(reviewImageRepository.findByReviewIdIn(anyList()))
             .willReturn(List.of(reviewImage));
 
-        List<ReadReviewResponseDto> reviews = reviewService.getProductReviewList(user1, 1L,
+        List<ReadReviewResponseDto> reviews = reviewService.readProductReviewList(user1, 1L,
             requestDto, PageRequest.of(0, 20)).getContent();
 
         assertThat(reviews.size()).isLessThanOrEqualTo(5); // user1은 준회원이기 때문에 최대 5개까지만 조회됨
@@ -195,7 +195,7 @@ class ReviewServiceTest {
         given(reviewImageRepository.findByReviewIdIn(anyList()))
             .willReturn(List.of(reviewImage));
 
-        List<ReadReviewResponseDto> reviews = reviewService.getProductReviewList(user2, 1L,
+        List<ReadReviewResponseDto> reviews = reviewService.readProductReviewList(user2, 1L,
             requestDto, PageRequest.of(0, 20)).getContent();
 
         assertThat(reviews.size()).isEqualTo(6); // user2는 정회원이므로 6개가 조회됨
@@ -212,7 +212,7 @@ class ReviewServiceTest {
             List.of(4, 5), ReviewSortBy.LATEST);
 
         assertThrows(ForbiddenUserException.class,
-            () -> reviewService.getProductReviewList(user1, 1L, requestDto, PageRequest.of(1, 20)));
+            () -> reviewService.readProductReviewList(user1, 1L, requestDto, PageRequest.of(1, 20)));
     }
 
     @Test
@@ -222,7 +222,7 @@ class ReviewServiceTest {
             List.of(4, 5), null);
 
         assertThrows(ForbiddenUserException.class,
-            () -> reviewService.getProductReviewList(null, 1L, requestDto, PageRequest.of(1, 20)));
+            () -> reviewService.readProductReviewList(null, 1L, requestDto, PageRequest.of(1, 20)));
     }
 
     @Test

--- a/src/test/java/com/cvsgo/service/ReviewServiceTest.java
+++ b/src/test/java/com/cvsgo/service/ReviewServiceTest.java
@@ -105,7 +105,7 @@ class ReviewServiceTest {
         ReadReviewRequestDto requestDto = new ReadReviewRequestDto(List.of(1L, 2L, 3L),
             List.of(4, 5), ReviewSortBy.LATEST);
 
-        given(reviewRepository.findAllByFilter(any(), anyLong(), any(), any()))
+        given(reviewRepository.findAllByProductIdAndFilter(any(), anyLong(), any(), any()))
             .willReturn(List.of(queryDto1));
         given(reviewRepository.countByProductIdAndFilter(anyLong(), any()))
             .willReturn(1L);
@@ -118,7 +118,8 @@ class ReviewServiceTest {
             requestDto, PageRequest.of(0, 20)).getContent();
 
         assertThat(reviews.size()).isEqualTo(1);
-        then(reviewRepository).should(times(1)).findAllByFilter(any(), anyLong(), any(), any());
+        then(reviewRepository).should(times(1))
+            .findAllByProductIdAndFilter(any(), anyLong(), any(), any());
         then(reviewRepository).should(times(1)).countByProductIdAndFilter(anyLong(), any());
         then(userTagRepository).should(times(1)).findByUserIdIn(any());
         then(reviewImageRepository).should(times(1)).findByReviewIdIn(any());
@@ -139,11 +140,13 @@ class ReviewServiceTest {
         PageRequest size20 = PageRequest.of(0, 20);
         PageRequest size5 = PageRequest.of(0, 5);
 
-        lenient().when(reviewRepository.findAllByFilter(any(), anyLong(), any(), eq(size20)))
+        lenient().when(
+                reviewRepository.findAllByProductIdAndFilter(any(), anyLong(), any(), eq(size20)))
             .thenReturn(List.of(queryDto1, queryDto2, queryDto3, queryDto4, queryDto5,
                 queryDto6)); // page size가 20인 경우 6개
         lenient().when(reviewRepository.countByProductIdAndFilter(anyLong(), any())).thenReturn(6L);
-        lenient().when(reviewRepository.findAllByFilter(any(), anyLong(), any(), eq(size5)))
+        lenient().when(
+                reviewRepository.findAllByProductIdAndFilter(any(), anyLong(), any(), eq(size5)))
             .thenReturn(List.of(queryDto1, queryDto2, queryDto3, queryDto4,
                 queryDto5)); // page size가 5인 경우 5개
         lenient().when(reviewRepository.countByProductIdAndFilter(anyLong(), any())).thenReturn(5L);
@@ -156,7 +159,8 @@ class ReviewServiceTest {
             requestDto, PageRequest.of(0, 20)).getContent();
 
         assertThat(reviews.size()).isLessThanOrEqualTo(5); // user1은 준회원이기 때문에 최대 5개까지만 조회됨
-        then(reviewRepository).should(times(1)).findAllByFilter(any(), anyLong(), any(), any());
+        then(reviewRepository).should(times(1))
+            .findAllByProductIdAndFilter(any(), anyLong(), any(), any());
         then(userTagRepository).should(times(1)).findByUserIdIn(any());
         then(reviewImageRepository).should(times(1)).findByReviewIdIn(any());
     }
@@ -176,11 +180,13 @@ class ReviewServiceTest {
         PageRequest size20 = PageRequest.of(0, 20);
         PageRequest size5 = PageRequest.of(0, 5);
 
-        lenient().when(reviewRepository.findAllByFilter(any(), anyLong(), any(), eq(size20)))
+        lenient().when(
+                reviewRepository.findAllByProductIdAndFilter(any(), anyLong(), any(), eq(size20)))
             .thenReturn(List.of(queryDto1, queryDto2, queryDto3, queryDto4, queryDto5,
                 queryDto6)); // page size가 20인 경우 6개
         lenient().when(reviewRepository.countByProductIdAndFilter(anyLong(), any())).thenReturn(6L);
-        lenient().when(reviewRepository.findAllByFilter(any(), anyLong(), any(), eq(size5)))
+        lenient().when(
+                reviewRepository.findAllByProductIdAndFilter(any(), anyLong(), any(), eq(size5)))
             .thenReturn(List.of(queryDto1, queryDto2, queryDto3, queryDto4,
                 queryDto5)); // page size가 5인 경우 5개
         lenient().when(reviewRepository.countByProductIdAndFilter(anyLong(), any())).thenReturn(5L);
@@ -193,7 +199,8 @@ class ReviewServiceTest {
             requestDto, PageRequest.of(0, 20)).getContent();
 
         assertThat(reviews.size()).isEqualTo(6); // user2는 정회원이므로 6개가 조회됨
-        then(reviewRepository).should(times(1)).findAllByFilter(any(), anyLong(), any(), any());
+        then(reviewRepository).should(times(1))
+            .findAllByProductIdAndFilter(any(), anyLong(), any(), any());
         then(userTagRepository).should(times(1)).findByUserIdIn(any());
         then(reviewImageRepository).should(times(1)).findByReviewIdIn(any());
     }


### PR DESCRIPTION
### 🎯 Issue
- #44

### 🔑 Key Changes
- 특정 상품의 리뷰 목록을 조회하는 API를 추가했습니다.
- 정회원이 아닌 경우 리뷰를 5개까지만 조회할 수 있도록 하였습니다.
- `/api/products/*/reviews` path의 `GET` method는 인증이 필요하지 않고, `POST` method는 인증이 필요하기 때문에 LoginInterceptor의 preHandle 메소드에서 AntPathMatcher를 사용하여 분기 처리 하였습니다.

