### PR TITLE
상품 좋아요, 북마크 생성 / 삭제 리팩토링

### DIFF
--- a/src/main/java/com/cvsgo/controller/ProductController.java
+++ b/src/main/java/com/cvsgo/controller/ProductController.java
@@ -9,6 +9,7 @@ import com.cvsgo.dto.product.ReadProductRequestDto;
 import com.cvsgo.entity.User;
 import com.cvsgo.service.ProductService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
@@ -22,6 +23,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/products")
@@ -48,7 +50,8 @@ public class ProductController {
         try {
             productService.createProductLike(user, productId);
         } catch (ObjectOptimisticLockingFailureException e) {
-            return createProductLike(user, productId);
+            log.info("상품 좋아요 생성 동시성 문제 발생");
+            throw e;
         }
         return SuccessResponse.create();
     }
@@ -59,7 +62,8 @@ public class ProductController {
         try {
             productService.deleteProductLike(user, productId);
         } catch (ObjectOptimisticLockingFailureException e) {
-            return deleteProductLike(user, productId);
+            log.info("상품 좋아요 삭제 동시성 문제 발생");
+            throw e;
         }
         return SuccessResponse.create();
     }

--- a/src/main/java/com/cvsgo/controller/ProductController.java
+++ b/src/main/java/com/cvsgo/controller/ProductController.java
@@ -4,8 +4,8 @@ import com.cvsgo.argumentresolver.LoginUser;
 import com.cvsgo.dto.SuccessResponse;
 import com.cvsgo.dto.product.ReadProductDetailResponseDto;
 import com.cvsgo.dto.product.ReadProductFilterResponseDto;
-import com.cvsgo.dto.product.ReadProductResponseDto;
 import com.cvsgo.dto.product.ReadProductRequestDto;
+import com.cvsgo.dto.product.ReadProductResponseDto;
 import com.cvsgo.entity.User;
 import com.cvsgo.service.ProductService;
 import lombok.RequiredArgsConstructor;
@@ -13,7 +13,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
-import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -47,24 +46,14 @@ public class ProductController {
     @ResponseStatus(HttpStatus.CREATED)
     public SuccessResponse<Void> createProductLike(@LoginUser User user,
         @PathVariable Long productId) {
-        try {
-            productService.createProductLike(user, productId);
-        } catch (ObjectOptimisticLockingFailureException e) {
-            log.info("상품 좋아요 생성 동시성 문제 발생");
-            throw e;
-        }
+        productService.createProductLike(user, productId);
         return SuccessResponse.create();
     }
 
     @DeleteMapping("/{productId}/likes")
     public SuccessResponse<Void> deleteProductLike(@LoginUser User user,
         @PathVariable Long productId) {
-        try {
-            productService.deleteProductLike(user, productId);
-        } catch (ObjectOptimisticLockingFailureException e) {
-            log.info("상품 좋아요 삭제 동시성 문제 발생");
-            throw e;
-        }
+        productService.deleteProductLike(user, productId);
         return SuccessResponse.create();
     }
 

--- a/src/main/java/com/cvsgo/dto/product/ReadProductDetailResponseDto.java
+++ b/src/main/java/com/cvsgo/dto/product/ReadProductDetailResponseDto.java
@@ -5,7 +5,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
-@Setter
 @Getter
 public class ReadProductDetailResponseDto {
 

--- a/src/main/java/com/cvsgo/entity/Product.java
+++ b/src/main/java/com/cvsgo/entity/Product.java
@@ -14,11 +14,9 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
-import org.hibernate.annotations.DynamicInsert;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@DynamicInsert
 @Entity
 public class Product extends BaseTimeEntity {
 

--- a/src/main/java/com/cvsgo/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/cvsgo/exception/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.security.SignatureException;
 import java.io.IOException;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.validation.BindException;
@@ -77,6 +78,13 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(ObjectOptimisticLockingFailureException.class)
     public ErrorResponse handleObjectOptimisticLockingFailureException(ObjectOptimisticLockingFailureException e) {
         log.info("상품 좋아요 동시성 문제 발생", e);
+        return ErrorResponse.of(ErrorCode.UNEXPECTED_ERROR.name(), e.getMessage());
+    }
+
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ErrorResponse handleDataIntegrityViolationException(DataIntegrityViolationException e) {
+        log.info("데이터 무결성 위반 문제 발생", e);
         return ErrorResponse.of(ErrorCode.UNEXPECTED_ERROR.name(), e.getMessage());
     }
 

--- a/src/main/java/com/cvsgo/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/cvsgo/exception/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import io.jsonwebtoken.security.SignatureException;
 import java.io.IOException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.validation.BindException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -70,6 +71,13 @@ public class GlobalExceptionHandler {
     public ErrorResponse handleDuplicateException(DuplicateException e) {
         log.info(e.getMessage(), e);
         return ErrorResponse.from(e.getErrorCode());
+    }
+
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ExceptionHandler(ObjectOptimisticLockingFailureException.class)
+    public ErrorResponse handleObjectOptimisticLockingFailureException(ObjectOptimisticLockingFailureException e) {
+        log.info("상품 좋아요 동시성 문제 발생", e);
+        return ErrorResponse.of(ErrorCode.UNEXPECTED_ERROR.name(), e.getMessage());
     }
 
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)

--- a/src/main/java/com/cvsgo/repository/ProductBookmarkRepository.java
+++ b/src/main/java/com/cvsgo/repository/ProductBookmarkRepository.java
@@ -10,4 +10,6 @@ public interface ProductBookmarkRepository extends JpaRepository<ProductBookmark
 
     Optional<ProductBookmark> findByProductAndUser(Product product, User user);
 
+    boolean existsByProductAndUser(Product product, User user);
+
 }

--- a/src/main/java/com/cvsgo/repository/ProductLikeRepository.java
+++ b/src/main/java/com/cvsgo/repository/ProductLikeRepository.java
@@ -10,4 +10,6 @@ public interface ProductLikeRepository extends JpaRepository<ProductLike, Long> 
 
     Optional<ProductLike> findByProductAndUser(Product product, User user);
 
+    boolean existsByProductAndUser(Product product, User user);
+
 }

--- a/src/main/java/com/cvsgo/service/ProductService.java
+++ b/src/main/java/com/cvsgo/service/ProductService.java
@@ -94,7 +94,7 @@ public class ProductService {
      * @throws NotFoundException  해당하는 아이디를 가진 상품이 없는 경우
      * @throws DuplicateException 이미 해당하는 상품 좋아요가 존재하는 경우
      */
-    @Transactional(rollbackFor = Exception.class)
+    @Transactional
     public void createProductLike(User user, Long productId) {
         Product product = productRepository.findByIdWithOptimisticLock(productId)
             .orElseThrow(() -> NOT_FOUND_PRODUCT);
@@ -116,7 +116,7 @@ public class ProductService {
      * @throws NotFoundException 해당하는 아이디를 가진 상품이 없는 경우
      * @throws NotFoundException 해당하는 상품 좋아요가 없는 경우
      */
-    @Transactional(rollbackFor = Exception.class)
+    @Transactional
     public void deleteProductLike(User user, Long productId) {
         Product product = productRepository.findByIdWithOptimisticLock(productId)
             .orElseThrow(() -> NOT_FOUND_PRODUCT);
@@ -135,7 +135,7 @@ public class ProductService {
      * @throws NotFoundException  해당하는 아이디를 가진 상품이 없는 경우
      * @throws DuplicateException 이미 해당하는 상품 북마크가 존재하는 경우
      */
-    @Transactional(rollbackFor = Exception.class)
+    @Transactional
     public void createProductBookmark(User user, Long productId) {
         Product product = productRepository.findById(productId)
             .orElseThrow(() -> NOT_FOUND_PRODUCT);
@@ -156,7 +156,7 @@ public class ProductService {
      * @throws NotFoundException 해당하는 아이디를 가진 상품이 없는 경우
      * @throws NotFoundException 해당하는 상품 북마크가 없는 경우
      */
-    @Transactional(rollbackFor = Exception.class)
+    @Transactional
     public void deleteProductBookmark(User user, Long productId) {
         Product product = productRepository.findById(productId)
             .orElseThrow(() -> NOT_FOUND_PRODUCT);

--- a/src/main/java/com/cvsgo/service/ProductService.java
+++ b/src/main/java/com/cvsgo/service/ProductService.java
@@ -37,6 +37,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/src/main/java/com/cvsgo/service/ProductService.java
+++ b/src/main/java/com/cvsgo/service/ProductService.java
@@ -11,12 +11,12 @@ import com.cvsgo.dto.product.ConvenienceStoreDto;
 import com.cvsgo.dto.product.ConvenienceStoreEventDto;
 import com.cvsgo.dto.product.ConvenienceStoreEventQueryDto;
 import com.cvsgo.dto.product.EventTypeDto;
+import com.cvsgo.dto.product.ReadProductDetailQueryDto;
 import com.cvsgo.dto.product.ReadProductDetailResponseDto;
 import com.cvsgo.dto.product.ReadProductFilterResponseDto;
-import com.cvsgo.dto.product.ReadProductResponseDto;
-import com.cvsgo.dto.product.ReadProductDetailQueryDto;
 import com.cvsgo.dto.product.ReadProductQueryDto;
 import com.cvsgo.dto.product.ReadProductRequestDto;
+import com.cvsgo.dto.product.ReadProductResponseDto;
 import com.cvsgo.entity.EventType;
 import com.cvsgo.entity.Product;
 import com.cvsgo.entity.ProductBookmark;
@@ -34,7 +34,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -100,12 +99,12 @@ public class ProductService {
         Product product = productRepository.findByIdWithOptimisticLock(productId)
             .orElseThrow(() -> NOT_FOUND_PRODUCT);
 
-        ProductLike productLike = ProductLike.create(user, product);
-        try {
-            productLikeRepository.save(productLike);
-        } catch (DataIntegrityViolationException e) {
+        if (productLikeRepository.existsByProductAndUser(product, user)) {
             throw DUPLICATE_PRODUCT_LIKE;
         }
+
+        ProductLike productLike = ProductLike.create(user, product);
+        productLikeRepository.save(productLike);
         product.plusLikeCount();
     }
 
@@ -141,12 +140,12 @@ public class ProductService {
         Product product = productRepository.findById(productId)
             .orElseThrow(() -> NOT_FOUND_PRODUCT);
 
-        ProductBookmark productBookmark = ProductBookmark.create(user, product);
-        try {
-            productBookmarkRepository.save(productBookmark);
-        } catch (DataIntegrityViolationException e) {
+        if (productBookmarkRepository.existsByProductAndUser(product, user)) {
             throw DUPLICATE_PRODUCT_BOOKMARK;
         }
+
+        ProductBookmark productBookmark = ProductBookmark.create(user, product);
+        productBookmarkRepository.save(productBookmark);
     }
 
     /**

--- a/src/test/java/com/cvsgo/repository/ProductBookmarkRepositoryTest.java
+++ b/src/test/java/com/cvsgo/repository/ProductBookmarkRepositoryTest.java
@@ -5,10 +5,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.cvsgo.config.TestConfig;
 import com.cvsgo.entity.Product;
 import com.cvsgo.entity.ProductBookmark;
-import com.cvsgo.entity.Role;
 import com.cvsgo.entity.User;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -30,29 +31,38 @@ class ProductBookmarkRepositoryTest {
     @Autowired
     ProductBookmarkRepository productBookmarkRepository;
 
+    @BeforeEach
+    void initData() {
+        user1 = User.create("abc@naver.com", "password1!", "닉네임", new ArrayList<>());
+        user2 = User.create("abcd@naver.com", "password1!", "닉네임2", new ArrayList<>());
+        userRepository.save(user1);
+        userRepository.save(user2);
+
+        product1 = Product.builder()
+            .name("상품1")
+            .price(1000)
+            .build();
+        product2 = Product.builder()
+            .name("상품2")
+            .price(2000)
+            .build();
+        productRepository.saveAll(List.of(product1, product2));
+
+        productBookmark1 = ProductBookmark.builder()
+            .product(product1)
+            .user(user1)
+            .build();
+        productBookmarkRepository.save(productBookmark1);
+    }
+
     @Test
     @DisplayName("상품 북마크를 추가한다")
     void succeed_to_save_product_bookmark() {
         // given
-        User user = User.builder()
-            .userId("abc@gmail.com")
-            .password("12345678a!")
-            .nickname("닉네임1")
-            .role(Role.ASSOCIATE)
-            .build();
-
-        Product product = Product.builder()
-            .name("상품1")
-            .price(1000)
-            .build();
-
         ProductBookmark productBookmark = ProductBookmark.builder()
-            .product(product)
-            .user(user)
+            .product(product2)
+            .user(user1)
             .build();
-
-        userRepository.save(user);
-        productRepository.save(product);
 
         // when
         productBookmarkRepository.save(productBookmark);
@@ -65,78 +75,47 @@ class ProductBookmarkRepositoryTest {
     @DisplayName("상품 북마크를 삭제한다")
     void succeed_to_delete_product_bookmark() {
         // given
-        User user = User.builder()
-            .userId("abc@gmail.com")
-            .password("12345678a!")
-            .nickname("닉네임1")
-            .role(Role.ASSOCIATE)
-            .build();
-
-        Product product = Product.builder()
-            .name("상품1")
-            .price(1000)
-            .build();
-
-        ProductBookmark productBookmark = ProductBookmark.builder()
-            .product(product)
-            .user(user)
-            .build();
-
-        userRepository.save(user);
-        productRepository.save(product);
-        productBookmarkRepository.save(productBookmark);
         Optional<ProductBookmark> foundProductBookmark = productBookmarkRepository.findByProductAndUser(
-            product, user);
+            product1, user1);
 
         // when
         foundProductBookmark.ifPresent(selectProductBookmark ->
             productBookmarkRepository.delete(selectProductBookmark)
         );
         Optional<ProductBookmark> deletedProductBookmark = productBookmarkRepository.findByProductAndUser(
-            product, user);
+            product1, user1);
 
         // then
+        assertThat(foundProductBookmark).isPresent();
         assertThat(deletedProductBookmark).isNotPresent();
     }
 
     @Test
     @DisplayName("해당하는 상품 북마크를 조회한다")
     void succeed_to_find_product_bookmark_by_product_and_user() {
-        // given
-        User user = User.builder()
-            .userId("abc@gmail.com")
-            .password("12345678a!")
-            .nickname("닉네임1")
-            .role(Role.ASSOCIATE)
-            .build();
-
-        Product product1 = Product.builder()
-            .name("상품1")
-            .price(1000)
-            .build();
-
-        Product product2 = Product.builder()
-            .name("상품2")
-            .price(5000)
-            .build();
-
-        ProductBookmark product1UserBookmark = ProductBookmark.builder()
-            .product(product1)
-            .user(user)
-            .build();
-
-        userRepository.save(user);
-        productRepository.saveAll(List.of(product1, product2));
-        productBookmarkRepository.save(product1UserBookmark);
-
-        // when
         Optional<ProductBookmark> productBookmark1 = productBookmarkRepository.findByProductAndUser(
-            product1, user);
+            product1, user1);
         Optional<ProductBookmark> productBookmark2 = productBookmarkRepository.findByProductAndUser(
-            product2, user);
+            product2, user1);
 
         // then
         assertThat(productBookmark1).isPresent();
         assertThat(productBookmark2).isNotPresent();
     }
+
+    @Test
+    @DisplayName("해당하는 상품 북마크가 있는지 확인한다")
+    void succeed_to_find_existing_product_bookmark_by_product_and_user() {
+        boolean user1ProductBookmark = productBookmarkRepository.existsByProductAndUser(product1, user1);
+        boolean user2ProductBookmark = productBookmarkRepository.existsByProductAndUser(product1, user2);
+
+        assertThat(user1ProductBookmark).isTrue();
+        assertThat(user2ProductBookmark).isFalse();
+    }
+
+    User user1;
+    User user2;
+    Product product1;
+    Product product2;
+    ProductBookmark productBookmark1;
 }


### PR DESCRIPTION
### 🎯 Issue
- #63 

### 🔑 Key Changes
- 상품 좋아요 생성, 상품 북마크 생성 시 객체 save 전 exists로 데이터 존재 여부를 확인합니다.
- 상품 좋아요 생성, 상품 좋아요 삭제 API 실행 중 동시성 문제 발생 시 재시도를 하는 로직에서 에러를 던지는 로직으로 변경했습니다.
- 컨트롤러 테스트 코드 에러 상황을 추가했습니다.
- `rollbackFor` 옵션을 삭제했습니다.
- dto에서 사용하지 않게 된 `@Setter` 어노테이션을 삭제했습니다.
