### PR TITLE
파일 업로드 용량 제한 변경

### DIFF
--- a/src/main/java/com/cvsgo/exception/ErrorCode.java
+++ b/src/main/java/com/cvsgo/exception/ErrorCode.java
@@ -10,6 +10,7 @@ public enum ErrorCode {
     /* 400 BAD_REQUEST */
     INVALID_REQUEST("유효성 검사에 실패했습니다."),
     INVALID_USER_FOLLOW("본인을 팔로우할 수 없습니다."),
+    INVALID_FILE_SIZE("파일 최대 용량을 초과하였습니다."),
 
     /* 401 UNAUTHORIZED */
     UNAUTHORIZED_USER("로그인을 하지 않은 사용자입니다."),

--- a/src/main/java/com/cvsgo/exception/ExceptionConstants.java
+++ b/src/main/java/com/cvsgo/exception/ExceptionConstants.java
@@ -7,6 +7,8 @@ public interface ExceptionConstants {
     UnauthorizedException INVALID_PASSWORD = new UnauthorizedException(ErrorCode.INVALID_PASSWORD);
     UnauthorizedException UNAUTHORIZED_USER = new UnauthorizedException(ErrorCode.UNAUTHORIZED_USER);
 
+    BadRequestException INVALID_FILE_SIZE = new BadRequestException(ErrorCode.INVALID_FILE_SIZE);
+
     ForbiddenException FORBIDDEN_REVIEW = new ForbiddenException(ErrorCode.FORBIDDEN_REVIEW);
 
     NotFoundException NOT_FOUND_USER = new NotFoundException(ErrorCode.NOT_FOUND_USER);

--- a/src/main/java/com/cvsgo/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/cvsgo/exception/GlobalExceptionHandler.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
 @Slf4j
 @RestControllerAdvice
@@ -86,6 +87,13 @@ public class GlobalExceptionHandler {
     public ErrorResponse handleDataIntegrityViolationException(DataIntegrityViolationException e) {
         log.info("데이터 무결성 위반 문제 발생", e);
         return ErrorResponse.of(ErrorCode.UNEXPECTED_ERROR.name(), e.getMessage());
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    public ErrorResponse handleFileSizeLimitExceededException(MaxUploadSizeExceededException e) {
+        log.info("파일 크기 초과", e);
+        return ErrorResponse.from(ErrorCode.INVALID_FILE_SIZE);
     }
 
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,5 @@
+spring:
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 128MB


### PR DESCRIPTION
### 🎯 Issue
- #77

### 🔑 Key Changes
- 단일 요청 파일 최대 크기 10MB로 수정
- 요청 최대 크기 128MB로 수정
- 용량 초과시 에러 메시지 추가

